### PR TITLE
Browse.pm: - Remove deprecated defined(@array)

### DIFF
--- a/lib/BackupPC/CGI/Browse.pm
+++ b/lib/BackupPC/CGI/Browse.pm
@@ -65,7 +65,7 @@ sub action
     #
     # default to the newest backup
     #
-    if ( !defined($In{num}) && defined(@Backups) && @Backups > 0 ) {
+    if ( !defined($In{num}) && @Backups > 0 ) {
         $i = @Backups - 1;
         $num = $Backups[$i]{num};
     }


### PR DESCRIPTION
Using an array as a reference cause fatal error with Perl-5.22.

Using "defined(@array)" has been deprecated since v5.6.1, has raised deprecation warnings since v5.16 and, with Perl 5.22, is not tolerated any more.

http://search.cpan.org/dist/perl-5.22.0/pod/perldelta.pod#defined(@array)_and_defined(%hash)_are_now_fatal_errors
