### PR TITLE
BackupPC.pod: Add "=encoding" declaration.

### DIFF
--- a/doc/BackupPC.pod
+++ b/doc/BackupPC.pod
@@ -1,3 +1,5 @@
+=encoding ISO8859-1
+
 =head1 BackupPC Introduction
 
 This documentation describes BackupPC version 4.0.0alpha3,


### PR DESCRIPTION
This commit fixes pod2man error with perl 5.18.
The default in pod2man was changed to warn on formatting errors instead of silently sticking the errors into the generated POD documentation. An "=encoding" declaration is not optional any more if there are non-ASCII characters in the POD.

How to reproduce:

```
# perl -v
This is perl 5, version 18, subversion 2 (v5.18.2) built for i386-freebsd-thread-multi-64int

# pod2man --section=1 --release="3.3.0" --name=BackupPC --center="BackupPC user guide" ./doc/BackupPC.pod ./backuppc.1
./doc/BackupPC.pod around line 4800: Non-ASCII character seen before =encoding in 'Paъgang.'. Assuming ISO8859-1
POD document had syntax errors at /usr/local/bin/pod2man line 71.
```

P.S. The pod2man warning stops installation of the sysutils/backuppc and sysutils/backuppc-devel ports on FreeBSD with perl 5.18.
