### PR TITLE
[Minor] Fix some rrdUpdate issues

### DIFF
--- a/bin/BackupPC_rrdUpdate
+++ b/bin/BackupPC_rrdUpdate
@@ -109,7 +109,7 @@ sub RRDUpdate
     }
     $sizeTot = $sizeTot / 1024;
 
-    print $bpc->cmdSystemOrEval(
+    if ( $err = $bpc->cmdSystemOrEval(
             [
                 $Conf{RrdToolPath},
                 "update", $RRDFile,
@@ -119,13 +119,17 @@ sub RRDUpdate
                 . $Info{"poolKb"}  . ":"
                 . $Info{"pool4Kb"} . ":"
                 . $Info{"cpool4Kb"}
-            ]);
-     printf("%sRRD updated:"
+            ]) ) {
+        print "$err";
+    }
+    else {
+        printf("%sRRD updated:"
           . " date %s; cpoolKb %f; total %f;"
           . " poolKb %f; pool4Kb %f; cpool4Kb %f\n",
                 $bpc->timeStamp,
                 $NowRnd1, $Info{"cpoolKb"}, $sizeTot,
                 $Info{"poolKb"}, $Info{"pool4Kb"}, $Info{"cpool4Kb"});
+    }
 }
 
 #

--- a/bin/BackupPC_rrdUpdate
+++ b/bin/BackupPC_rrdUpdate
@@ -144,7 +144,7 @@ sub RRDGraph
     #
     # Get each pool max value from RRD
     #
-    $bpc->cmdSystemOrEval(
+    $bpc->cmdSystemOrEvalLong(
             [
                 $Conf{RrdToolPath},
                 "graphv", "-",
@@ -162,7 +162,7 @@ sub RRDGraph
                 if ( $_[0] =~ /^print\[([0-3])\] = "([.0-9]+)"$/ ) {
                     $poolMax[$1] = $2 unless ( $2 == 0 );
                 }
-            });
+            }, 1, undef);
 
     my $poolSizeGraph = [
         "$Conf{RrdToolPath}",
@@ -232,6 +232,6 @@ sub RRDGraph
         print("Can't open/create $LogDir/poolUsage$weeks.png\n");
         return;
     }
-    $bpc->cmdSystemOrEval($poolSizeGraph, sub { print $fdOut $_[0] });
+    $bpc->cmdSystemOrEvalLong($poolSizeGraph, sub { print $fdOut $_[0] }, 1, undef);
     close($fdOut);
 }


### PR DESCRIPTION
[1] BackupPC_rrdUpdate reported successful update even though update failed:

```
2013-12-09 09:22:45 Running BackupPC_rrdUpdate (pid=1029)
2013-12-09 09:22:45  admin-1 : ERROR: /var/log/BackupPC/poolUsage.rrd: illegal attempt to update using time 1386633600 when last update time is 1386633600 (minimum one second step)
2013-12-09 09:22:45  admin-1 : 2013-12-09 09:22:45 RRD updated: date 1386633600; cpoolKb 0.000000; total 128744.500000; poolKb 0.000000; pool4Kb 0.000000; cpool4Kb 4632.000000
2013-12-09 09:22:47 Finished  admin-1  (BackupPC_rrdUpdate) 
```

[2] Switch from cmdSystemOrEval to cmdSystemOrEvalLong when getting stdout because of sub cmdSystemOrEval merges stdout and stderr together.

BackupPC_rrdUpdate creates broken images if the HOME environment variable set to a path non-readable by backuppc user (e.g. HOME=/root).
BackupPC_rrdUpdate writes stderr warnings into image files:

```
(process:2430): Pango-WARNING **: error opening config file '/root/.config/pango/pangorc': Permission denied
```
