### PR TITLE
[CritFix] Change full backup expire algorithm to aviod data loss

### DIFF
--- a/bin/BackupPC_dump
+++ b/bin/BackupPC_dump
@@ -1366,9 +1366,9 @@ sub BackupFullExpire
 
     #
     # If regular backups are still disabled with $Conf{FullPeriod} < 0,
-    # we still expire backups based on a typical FullPeriod value - weekly.
+    # we still expire backups based on a safe FullPeriod value - daily.
     #
-    $fullPeriod = 7 if ( $fullPeriod <= 0 );
+    $fullPeriod = 1 if ( $fullPeriod <= 0 );
 
     $fullKeepCnt = [$fullKeepCnt] if ( ref($fullKeepCnt) ne "ARRAY" );
 

--- a/bin/BackupPC_dump
+++ b/bin/BackupPC_dump
@@ -1352,7 +1352,6 @@ sub BackupFullExpire
     my($client, $Backups) = @_;
     my $fullCnt = 0;
     my $fullPeriod = $Conf{FullPeriod};
-    my $startTimeDeviation = $fullPeriod < 1 ? $fullPeriod / 2 : 0.5;
     my $nextFull;
     my $fullKeepCnt = $Conf{FullKeepCnt};
     my $fullKeepIdx = 0;
@@ -1371,6 +1370,7 @@ sub BackupFullExpire
     $fullPeriod = 1 if ( $fullPeriod <= 0 );
 
     $fullKeepCnt = [$fullKeepCnt] if ( ref($fullKeepCnt) ne "ARRAY" );
+    my $startTimeDeviation = $fullPeriod < 1 ? $fullPeriod / 2 : 0.5;
 
     for ( my $i = 0 ; $i < @$Backups ; $i++ ) {
         next if ( $Backups->[$i]{type} ne "full" );

--- a/bin/BackupPC_dump
+++ b/bin/BackupPC_dump
@@ -1372,7 +1372,7 @@ sub BackupFullExpire
     $fullKeepCnt = [$fullKeepCnt] if ( ref($fullKeepCnt) ne "ARRAY" );
     my $startTimeDeviation = $fullPeriod < 1 ? $fullPeriod / 2 : 0.5;
     my $keepPeriod =
-      ( $fullPeriod + $startTimeDeviation ) * $fullKeepCnt->[0] * 24 * 3600;
+      ( $fullPeriod * $fullKeepCnt->[0] - $startTimeDeviation ) * 24 * 3600;
 
     for ( my $i = 0 ; $i < @$Backups ; $i++ ) {
         next if ( $Backups->[$i]{type} ne "full" );
@@ -1405,7 +1405,8 @@ sub BackupFullExpire
             $fullCnt++;
             $nextFull = $i;
             while ( $fullKeepIdx < @$fullKeepCnt
-                     && time - $Backups->[$i]{startTime} > $keepPeriod
+                     && $k > 0
+                     && time - $Backups->[$prevFull]{startTime} > $keepPeriod
                      && $fullCnt >= $fullKeepCnt->[$fullKeepIdx] ) {
                 $fullKeepIdx++;
                 $fullCnt = 0;

--- a/bin/BackupPC_dump
+++ b/bin/BackupPC_dump
@@ -1352,7 +1352,8 @@ sub BackupFullExpire
     my($client, $Backups) = @_;
     my $fullCnt = 0;
     my $fullPeriod = $Conf{FullPeriod};
-    my $origFullPeriod = $fullPeriod;
+    my $startTimeDeviation = $fullPeriod < 1 ? $fullPeriod / 2 : 0.5;
+    my $nextFull;
     my $fullKeepCnt = $Conf{FullKeepCnt};
     my $fullKeepIdx = 0;
     my(@delete, @fullList);
@@ -1387,9 +1388,9 @@ sub BackupFullExpire
         if ( !$noDelete && 
               ($fullKeepIdx >= @$fullKeepCnt
               || $k > 0
-                 && $fullKeepIdx > 0
-                 && $Backups->[$i]{startTime} - $Backups->[$prevFull]{startTime}
-                             < ($fullPeriod - $origFullPeriod / 2) * 24 * 3600
+                 && defined($nextFull)
+                 && $Backups->[$nextFull]{startTime} - $Backups->[$prevFull]{startTime}
+                             < ($fullPeriod + $startTimeDeviation) * 24 * 3600
                )
             ) {
             #
@@ -1399,6 +1400,7 @@ sub BackupFullExpire
             unshift(@delete, $i);
         } else {
             $fullCnt++;
+            $nextFull = $i;
             while ( $fullKeepIdx < @$fullKeepCnt
                      && $fullCnt >= $fullKeepCnt->[$fullKeepIdx] ) {
                 $fullKeepIdx++;

--- a/bin/BackupPC_dump
+++ b/bin/BackupPC_dump
@@ -1371,6 +1371,8 @@ sub BackupFullExpire
 
     $fullKeepCnt = [$fullKeepCnt] if ( ref($fullKeepCnt) ne "ARRAY" );
     my $startTimeDeviation = $fullPeriod < 1 ? $fullPeriod / 2 : 0.5;
+    my $keepPeriod =
+      ( $fullPeriod + $startTimeDeviation ) * $fullKeepCnt->[0] * 24 * 3600;
 
     for ( my $i = 0 ; $i < @$Backups ; $i++ ) {
         next if ( $Backups->[$i]{type} ne "full" );
@@ -1388,6 +1390,7 @@ sub BackupFullExpire
         if ( !$noDelete && 
               ($fullKeepIdx >= @$fullKeepCnt
               || $k > 0
+                 && $fullKeepIdx > 0
                  && defined($nextFull)
                  && $Backups->[$nextFull]{startTime} - $Backups->[$prevFull]{startTime}
                              < ($fullPeriod + $startTimeDeviation) * 24 * 3600
@@ -1402,6 +1405,7 @@ sub BackupFullExpire
             $fullCnt++;
             $nextFull = $i;
             while ( $fullKeepIdx < @$fullKeepCnt
+                     && time - $Backups->[$i]{startTime} > $keepPeriod
                      && $fullCnt >= $fullKeepCnt->[$fullKeepIdx] ) {
                 $fullKeepIdx++;
                 $fullCnt = 0;


### PR DESCRIPTION
Proposed pull request fixes full backup expire exponential algorithm. Current algorithm has issues with backups loss after modifying configuration settings or making manual backups.

**A thorough review (not just LGTM) is required for this pull-request.**

Both v3 and v4 are affected. Pull requests are opened for both `master` and `v4.0.0` branches.

Explanation with some examples:
https://gist.github.com/moisseev/d5a8a499a7b69b1f0428#comment-1442896

Test script to play with:
https://gist.github.com/moisseev/d5a8a499a7b69b1f0428
It a simple wrapper for `BackupPC_dump` subroutines: `BackupExpire` and `BackupFullExpire`.
