### PR TITLE
[CritFix] Change full backup expire algorithm to aviod data loss

### DIFF
--- a/bin/BackupPC_dump
+++ b/bin/BackupPC_dump
@@ -1714,7 +1714,7 @@ sub BackupFullExpire
     $fullKeepCnt = [$fullKeepCnt] if ( ref($fullKeepCnt) ne "ARRAY" );
     my $startTimeDeviation = $fullPeriod < 1 ? $fullPeriod / 2 : 0.5;
     my $keepPeriod =
-      ( $fullPeriod + $startTimeDeviation ) * $fullKeepCnt->[0] * 24 * 3600;
+      ( $fullPeriod * $fullKeepCnt->[0] - $startTimeDeviation ) * 24 * 3600;
 
     for ( my $i = 0 ; $i < @$Backups ; $i++ ) {
         if ( $Backups[$i]{preV4} ) {
@@ -1752,7 +1752,8 @@ sub BackupFullExpire
             $fullCnt++;
             $nextFull = $i;
             while ( $fullKeepIdx < @$fullKeepCnt
-                     && time - $Backups->[$i]{startTime} > $keepPeriod
+                     && $k > 0
+                     && time - $Backups->[$prevFull]{startTime} > $keepPeriod
                      && $fullCnt >= $fullKeepCnt->[$fullKeepIdx] ) {
                 $fullKeepIdx++;
                 $fullCnt = 0;

--- a/bin/BackupPC_dump
+++ b/bin/BackupPC_dump
@@ -1713,6 +1713,8 @@ sub BackupFullExpire
 
     $fullKeepCnt = [$fullKeepCnt] if ( ref($fullKeepCnt) ne "ARRAY" );
     my $startTimeDeviation = $fullPeriod < 1 ? $fullPeriod / 2 : 0.5;
+    my $keepPeriod =
+      ( $fullPeriod + $startTimeDeviation ) * $fullKeepCnt->[0] * 24 * 3600;
 
     for ( my $i = 0 ; $i < @$Backups ; $i++ ) {
         if ( $Backups[$i]{preV4} ) {
@@ -1735,6 +1737,7 @@ sub BackupFullExpire
         if ( !$noDelete && 
               ($fullKeepIdx >= @$fullKeepCnt
               || $k > 0
+                 && $fullKeepIdx > 0
                  && defined($nextFull)
                  && $Backups->[$nextFull]{startTime} - $Backups->[$prevFull]{startTime}
                              < ($fullPeriod + $startTimeDeviation) * 24 * 3600
@@ -1749,6 +1752,7 @@ sub BackupFullExpire
             $fullCnt++;
             $nextFull = $i;
             while ( $fullKeepIdx < @$fullKeepCnt
+                     && time - $Backups->[$i]{startTime} > $keepPeriod
                      && $fullCnt >= $fullKeepCnt->[$fullKeepIdx] ) {
                 $fullKeepIdx++;
                 $fullCnt = 0;

--- a/bin/BackupPC_dump
+++ b/bin/BackupPC_dump
@@ -1708,9 +1708,9 @@ sub BackupFullExpire
 
     #
     # If regular backups are still disabled with $Conf{FullPeriod} < 0,
-    # we still expire backups based on a typical FullPeriod value - weekly.
+    # we still expire backups based on a safe FullPeriod value - daily.
     #
-    $fullPeriod = 7 if ( $fullPeriod <= 0 );
+    $fullPeriod = 1 if ( $fullPeriod <= 0 );
 
     $fullKeepCnt = [$fullKeepCnt] if ( ref($fullKeepCnt) ne "ARRAY" );
 

--- a/bin/BackupPC_dump
+++ b/bin/BackupPC_dump
@@ -1693,7 +1693,6 @@ sub BackupFullExpire
     my($client, $Backups) = @_;
     my $fullCnt = 0;
     my $fullPeriod = $Conf{FillCycle} <= 0 ? $Conf{FullPeriod} : $Conf{FillCycle};
-    my $startTimeDeviation = $fullPeriod < 1 ? $fullPeriod / 2 : 0.5;
     my $nextFull;
     my $fullKeepCnt = $Conf{FullKeepCnt};
     my $fullKeepIdx = 0;
@@ -1713,6 +1712,7 @@ sub BackupFullExpire
     $fullPeriod = 1 if ( $fullPeriod <= 0 );
 
     $fullKeepCnt = [$fullKeepCnt] if ( ref($fullKeepCnt) ne "ARRAY" );
+    my $startTimeDeviation = $fullPeriod < 1 ? $fullPeriod / 2 : 0.5;
 
     for ( my $i = 0 ; $i < @$Backups ; $i++ ) {
         if ( $Backups[$i]{preV4} ) {

--- a/bin/BackupPC_dump
+++ b/bin/BackupPC_dump
@@ -1693,7 +1693,8 @@ sub BackupFullExpire
     my($client, $Backups) = @_;
     my $fullCnt = 0;
     my $fullPeriod = $Conf{FillCycle} <= 0 ? $Conf{FullPeriod} : $Conf{FillCycle};
-    my $origFullPeriod = $fullPeriod;
+    my $startTimeDeviation = $fullPeriod < 1 ? $fullPeriod / 2 : 0.5;
+    my $nextFull;
     my $fullKeepCnt = $Conf{FullKeepCnt};
     my $fullKeepIdx = 0;
     my(@delete, @fullList);
@@ -1734,9 +1735,9 @@ sub BackupFullExpire
         if ( !$noDelete && 
               ($fullKeepIdx >= @$fullKeepCnt
               || $k > 0
-                 && $fullKeepIdx > 0
-                 && $Backups->[$i]{startTime} - $Backups->[$prevFull]{startTime}
-                             < ($fullPeriod - $origFullPeriod / 2) * 24 * 3600
+                 && defined($nextFull)
+                 && $Backups->[$nextFull]{startTime} - $Backups->[$prevFull]{startTime}
+                             < ($fullPeriod + $startTimeDeviation) * 24 * 3600
                )
             ) {
             #
@@ -1746,6 +1747,7 @@ sub BackupFullExpire
             unshift(@delete, $i);
         } else {
             $fullCnt++;
+            $nextFull = $i;
             while ( $fullKeepIdx < @$fullKeepCnt
                      && $fullCnt >= $fullKeepCnt->[$fullKeepIdx] ) {
                 $fullKeepIdx++;


### PR DESCRIPTION
Proposed pull request fixes full backup expire exponential algorithm. Current algorithm has issues with backups loss after modifying configuration settings or making manual backups.

**A thorough review (not just LGTM) is required for this pull-request.**

Both v3 and v4 are affected. Pull requests are opened for both `master` and `v4.0.0` branches.

Explanation with some examples:
https://gist.github.com/moisseev/d5a8a499a7b69b1f0428#comment-1442896

Test script to play with:
https://gist.github.com/moisseev/d5a8a499a7b69b1f0428
It a simple wrapper for `BackupPC_dump` subroutines: `BackupExpire` and `BackupFullExpire`.
