### PR TITLE
Add support for IPv6

### DIFF
--- a/bin/BackupPC_dump
+++ b/bin/BackupPC_dump
@@ -491,7 +491,7 @@ if ( !$opts{d} ) {
     } else {
         $host = $client;
     }
-    if ( !defined(gethostbyname($host)) ) {
+    if ( !defined($bpc->resolve($host)) ) {
         #
         # Ok, NS doesn't know about it.  Maybe it is a NetBios name
         # instead.

--- a/bin/BackupPC_restore
+++ b/bin/BackupPC_restore
@@ -170,7 +170,7 @@ if ( $Conf{ClientNameAlias} ne "" ) {
 # Find its IP address
 #
 if ( $hostIP !~ /\d+\.\d+\.\d+\.\d+/ ) {
-    if ( !defined(gethostbyname($host)) ) {
+    if ( !defined($bpc->resolve($host)) ) {
 	#
 	# Ok, NS doesn't know about it.  Maybe it is a NetBios name
 	# instead.

--- a/conf/config.pl
+++ b/conf/config.pl
@@ -1559,9 +1559,24 @@ $Conf{FixedIPNetBiosNameCheck} = 0;
 $Conf{PingPath} = '';
 
 #
+# Like PingPath, but for IPv6.  Security caution: normal users
+# should not be allowed to write to this file or directory.
+# In some environments, this is something like '/usr/bin/ping6'.
+# In modern environments, the regular ping command can handle both
+# IPv4 and IPv6. In the latter case, just set it to  $Conf{PingPath}
+#
+# If you want to disable ping checking for IPv6 hosts, set this to
+# some program that exits with 0 status, eg:
+#
+#     $Conf{PingPath6} = '/bin/echo';
+#
+$Conf{PingPath6} = '';
+
+#
 # Ping command.  The following variables are substituted at run-time:
 #
-#   $pingPath      path to ping ($Conf{PingPath})
+#   $pingPath      path to ping ($Conf{PingPath} or $Conf{PingPath6})
+#                  depending on the address type of $host.
 #   $host          host name
 #
 # Wade Brown reports that on solaris 2.6 and 2.7 ping -s returns the wrong

--- a/configure.pl
+++ b/configure.pl
@@ -269,6 +269,7 @@ my %Programs = (
     nmblookup      => "NmbLookupPath",
     rsync          => "RsyncClientPath",
     ping           => "PingPath",
+    'ping6/ping'   => "PingPath6",
     df             => "DfPath",
     'ssh/ssh2'     => "SshPath",
     sendmail       => "SendmailPath",

--- a/lib/BackupPC/CGI/EditConfig.pm
+++ b/lib/BackupPC/CGI/EditConfig.pm
@@ -86,6 +86,7 @@ our %ConfigMenu = (
 	    {name => "SshPath"},
 	    {name => "NmbLookupPath"},
 	    {name => "PingPath"},
+	    {name => "PingPath6"},
 	    {name => "DfPath"},
 	    {name => "SplitPath"},
 	    {name => "ParPath"},

--- a/lib/BackupPC/Config.pm
+++ b/lib/BackupPC/Config.pm
@@ -269,6 +269,9 @@ sub ConnectData
     PingPath                     => {struct => 'SCALAR',
                                      type   => 'STRING', },
 
+    PingPath6                    => {struct => 'SCALAR',
+                                     type   => 'STRING', },
+
     PingArgs                     => {struct => 'SCALAR',
                                      type   => 'STRING', },
 

--- a/lib/BackupPC/Config/Meta.pm
+++ b/lib/BackupPC/Config/Meta.pm
@@ -86,6 +86,7 @@ use vars qw(%ConfigMeta);
     SshPath	 	=> {type => "execPath", undefIfEmpty => 1},
     NmbLookupPath 	=> {type => "execPath", undefIfEmpty => 1},
     PingPath	 	=> {type => "execPath", undefIfEmpty => 1},
+    PingPath6	 	=> {type => "execPath", undefIfEmpty => 1},
     DfPath	 	=> {type => "execPath", undefIfEmpty => 1},
     DfCmd	 	=> "string",
     SplitPath	 	=> {type => "execPath", undefIfEmpty => 1},

--- a/lib/BackupPC/Lib.pm
+++ b/lib/BackupPC/Lib.pm
@@ -818,7 +818,7 @@ sub CheckHostAlive
     }
 
     my $args = {
-	pingPath => $bpc->{Conf}{PingPath},
+	pingPath => $bpc->getPingPathByAddressType( $host ),
 	host     => $host,
     };
     $pingCmd = $bpc->cmdVarSubstitute($bpc->{Conf}{PingCmd}, $args);
@@ -1386,6 +1386,29 @@ sub flushXSLibMesgs()
     foreach my $m ( @$msg ) {
         print($m);
     }
+}
+
+#
+# Attempts to resolve a hostname.
+# Return 4 if it resolves to an IPv4 address, 6 if it resolves to an IPv6
+# address or undef if it can not be resolved.
+#
+sub resolve
+{
+    my ( $bpc, $host ) = @_;
+    my ( $err, @addrs ) = Socket::getaddrinfo($host);
+    return undef if ( $err );
+    return (($addrs[0])->{'family'} == Socket::AF_INET6) ? 6 : 4;
+}
+
+#
+# Return pingPath depending on address type of target.
+#
+sub getPingPathByAddressType
+{
+    my ( $bpc, $host ) = @_;
+    my $at = $bpc->resolve( $host ) || 4;
+    return ($at == 6) ? $bpc->{Conf}{PingPath6} : $bpc->{Conf}{PingPath};
 }
 
 1;


### PR DESCRIPTION
This PR adds support for IPv6.
To support IPv6, there are basically 2 changes required:
1. Replace gethostbyname() - which works for IPv4 only - with similar functionality of Socket::getaddrinfo()
2. Some environments require the use of a different ping binary for IPv6 hosts.

The second change is implemented by introducing an additional config variable named PingPath6 which can be set to something like '/usr/bin/ping6' in such environments. For modern environments like Fedora, this can be set to /usr/bin/ping, because their standard ping supports both IPv4 and IPv6.

Cheers
 -Fritz
