### PR TITLE
[Minor] Escape "{" literal in regexps

### DIFF
--- a/lib/BackupPC/Lib.pm
+++ b/lib/BackupPC/Lib.pm
@@ -1261,7 +1261,7 @@ sub cmdVarSubstitute
         #
         # Replace scalar variables first
         #
-        $arg =~ s[\${(\w+)}(\+?)]{
+        $arg =~ s[\$\{(\w+)}(\+?)]{
             exists($vars->{$1}) && ref($vars->{$1}) ne "ARRAY"
                 ? ($2 eq "+" ? $bpc->shellEscape($vars->{$1}) : $vars->{$1})
                 : "\${$1}$2"
@@ -1270,7 +1270,7 @@ sub cmdVarSubstitute
         # Now replicate any array arguments; this just works for just one
         # array var in each argument.
         #
-        if ( $arg =~ m[(.*)\${(\w+)}(\+?)(.*)] && ref($vars->{$2}) eq "ARRAY" ) {
+        if ( $arg =~ m[(.*)\$\{(\w+)}(\+?)(.*)] && ref($vars->{$2}) eq "ARRAY" ) {
             my $pre  = $1;
             my $var  = $2;
             my $esc  = $3;


### PR DESCRIPTION
[perl5200delta](http://search.cpan.org/dist/perl-5.22.0/pod/perldelta.pod#A_literal_%22{%22_should_now_be_escaped_in_a_pattern)