### PR TITLE
Fix result for restore using Samba4

### DIFF
--- a/lib/BackupPC/Xfer/Smb.pm
+++ b/lib/BackupPC/Xfer/Smb.pm
@@ -241,7 +241,8 @@ sub readOutput
             $t->{xferOK} = 1;
             $t->{byteCnt} = $1;
             $t->{XferLOG}->write(\"$_\n") if ( $t->{logLevel} >= 0 );
-        } elsif ( /^\s*tar: restored \d+ files/ ) {
+        } elsif ( /^\s*tar: restored \d+ files/
+                    || /^\s*tar:\d+\s*tar_process done, err = 0/ ) {
             $t->{xferOK} = 1;
             $t->{XferLOG}->write(\"$_\n") if ( $t->{logLevel} >= 0 );
         } elsif ( /^\s*read_socket_with_timeout: timeout read. /i ) {


### PR DESCRIPTION
RestoreLOG sample:
```
tarCreate: Done: 1 files, 39 bytes, 0 dirs, 0 specials, 0 errors
 tconx ok
tar:316  tarmode is now full, system, hidden, noreset, quiet
tar:1052 +++ ./+/test/2 - Copy.txt
tar:632  tar_process done, err = 0
restore failed: tar:632  tar_process done, err = 0
```