### PR TITLE
Improvement for Gentoo init script

### DIFF
--- a/systemd/src/init.d/gentoo-backuppc
+++ b/systemd/src/init.d/gentoo-backuppc
@@ -1,4 +1,4 @@
-#!/sbin/runscript
+#!/sbin/openrc-run
 #
 # DESCRIPTION
 #
@@ -21,7 +21,7 @@ checkconfig() {
 start() {
 	checkconfig || return 1
 	ebegin "Starting BackupPC"
-	start-stop-daemon --start --chuid ${USER} --user ${USER} --pidfile ${PID_FILE} --exec ${EXEC} -- ${EXEC_OPTIONS}
+	start-stop-daemon --start --user ${USER} --group ${USER} --make-pidfile --pidfile ${PID_FILE} --exec ${EXEC} -- ${EXEC_OPTIONS}
 	eend $?
 }
 


### PR DESCRIPTION
 /sbin/runscript has been deprecated, /sbin/openrc-run is now recommended.
--chuid is also deprecated
--group is useful, although it is currently the same as USER (maybe this should be changed across BPC)
