### PR TITLE
configure.pl: Remove extra quotes from $Conf{CgiURL}

### DIFF
--- a/configure.pl
+++ b/configure.pl
@@ -573,9 +573,9 @@ $Conf{EMailAdminUserName} ||= $Conf{BackupPCUser};
 #
 if ( !defined($Conf{CgiURL}) ) {
     if ( $Conf{CgiDir} =~ m{cgi-bin(/.*)} ) {
-	$Conf{CgiURL} = "'http://$Conf{ServerHost}/cgi-bin$1/BackupPC_Admin'";
+	$Conf{CgiURL} = "http://$Conf{ServerHost}/cgi-bin$1/BackupPC_Admin";
     } else {
-	$Conf{CgiURL} = "'http://$Conf{ServerHost}/cgi-bin/BackupPC_Admin'";
+	$Conf{CgiURL} = "http://$Conf{ServerHost}/cgi-bin/BackupPC_Admin";
     }
 }
 


### PR DESCRIPTION
If the $Conf{CgiURL} is missed in the config.pl somehow, the configure.pl
creates it on upgrade like `$Conf{CgiURL} = ''http... ''`.
That breaks config.pl.