### PR TITLE
minor improvement for openrc init script

### DIFF
--- a/systemd/src/init.d/gentoo-backuppc
+++ b/systemd/src/init.d/gentoo-backuppc
@@ -21,9 +21,9 @@ checkconfig() {
 start() {
 	checkconfig || return 1
 
-   PID_DIR=$(dirname "${PID_FILE}")
-   mkdir -p "${PID_DIR}" || return 1
-   chown ${USER}:${USER} "${PID_DIR}" || return 1
+	PID_DIR=$(dirname "${PID_FILE}")
+	mkdir -p "${PID_DIR}" || return 1
+	chown ${USER}:${USER} "${PID_DIR}" || return 1
 
 	ebegin "Starting BackupPC"
 	start-stop-daemon --start --user ${USER} --group ${USER} --make-pidfile --pidfile ${PID_FILE} --exec ${EXEC} -- ${EXEC_OPTIONS}

--- a/systemd/src/init.d/gentoo-backuppc
+++ b/systemd/src/init.d/gentoo-backuppc
@@ -20,6 +20,11 @@ checkconfig() {
 
 start() {
 	checkconfig || return 1
+
+   PID_DIR=$(dirname "${PID_FILE}")
+   mkdir -p "${PID_DIR}" || return 1
+   chown ${USER}:${USER} "${PID_DIR}" || return 1
+
 	ebegin "Starting BackupPC"
 	start-stop-daemon --start --user ${USER} --group ${USER} --make-pidfile --pidfile ${PID_FILE} --exec ${EXEC} -- ${EXEC_OPTIONS}
 	eend $?
@@ -43,4 +48,3 @@ status() {
 	return
 	eend $?
 }
-


### PR DESCRIPTION
the parent of BPC pid must exist and be writable by the BPC user, otherwise the service fails to start with OpenRC. This fixes it.