### PR TITLE
updated FSF adress

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,9 +1,8 @@
-GNU GENERAL PUBLIC LICENSE
-
+                    GNU GENERAL PUBLIC LICENSE
                        Version 2, June 1991
 
- Copyright (C) 1989, 1991 Free Software Foundation, Inc.
-                       59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 
@@ -16,7 +15,7 @@ software--to make sure the software is free for all its users.  This
 General Public License applies to most of the Free Software
 Foundation's software and to any other program whose authors commit to
 using it.  (Some other Free Software Foundation software is covered by
-the GNU Library General Public License instead.)  You can apply it to
+the GNU Lesser General Public License instead.)  You can apply it to
 your programs, too.
 
   When we speak of free software, we are referring to freedom, not

--- a/bin/BackupPC
+++ b/bin/BackupPC
@@ -43,7 +43,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1335  USA
 #
 #========================================================================
 #

--- a/bin/BackupPC_archive
+++ b/bin/BackupPC_archive
@@ -25,7 +25,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1335  USA
 #
 #========================================================================
 #

--- a/bin/BackupPC_archiveHost
+++ b/bin/BackupPC_archiveHost
@@ -34,7 +34,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1335  USA
 #
 #========================================================================
 #

--- a/bin/BackupPC_archiveStart
+++ b/bin/BackupPC_archiveStart
@@ -31,7 +31,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1335  USA
 #
 #========================================================================
 #

--- a/bin/BackupPC_attribPrint
+++ b/bin/BackupPC_attribPrint
@@ -27,7 +27,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1335  USA
 #
 #========================================================================
 #

--- a/bin/BackupPC_dump
+++ b/bin/BackupPC_dump
@@ -73,7 +73,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1335  USA
 #
 #========================================================================
 #

--- a/bin/BackupPC_fixupBackupSummary
+++ b/bin/BackupPC_fixupBackupSummary
@@ -26,7 +26,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1335  USA
 #
 #========================================================================
 #

--- a/bin/BackupPC_link
+++ b/bin/BackupPC_link
@@ -35,7 +35,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1335  USA
 #
 #========================================================================
 #

--- a/bin/BackupPC_nightly
+++ b/bin/BackupPC_nightly
@@ -51,7 +51,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1335  USA
 #
 #========================================================================
 #

--- a/bin/BackupPC_restore
+++ b/bin/BackupPC_restore
@@ -25,7 +25,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1335  USA
 #
 #========================================================================
 #

--- a/bin/BackupPC_sendEmail
+++ b/bin/BackupPC_sendEmail
@@ -27,7 +27,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1335  USA
 #
 #========================================================================
 #

--- a/bin/BackupPC_serverMesg
+++ b/bin/BackupPC_serverMesg
@@ -39,7 +39,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1335  USA
 #
 #========================================================================
 #

--- a/bin/BackupPC_tarCreate
+++ b/bin/BackupPC_tarCreate
@@ -51,7 +51,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1335  USA
 #
 #========================================================================
 #

--- a/bin/BackupPC_tarExtract
+++ b/bin/BackupPC_tarExtract
@@ -23,7 +23,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1335  USA
 #
 #========================================================================
 #

--- a/bin/BackupPC_tarPCCopy
+++ b/bin/BackupPC_tarPCCopy
@@ -34,7 +34,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1335  USA
 #
 #========================================================================
 #

--- a/bin/BackupPC_trashClean
+++ b/bin/BackupPC_trashClean
@@ -25,7 +25,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1335  USA
 #
 #========================================================================
 #

--- a/bin/BackupPC_zcat
+++ b/bin/BackupPC_zcat
@@ -28,7 +28,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1335  USA
 #
 #========================================================================
 #

--- a/bin/BackupPC_zipCreate
+++ b/bin/BackupPC_zipCreate
@@ -47,7 +47,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1335  USA
 #
 #========================================================================
 #

--- a/cgi-bin/BackupPC_Admin
+++ b/cgi-bin/BackupPC_Admin
@@ -35,7 +35,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1335  USA
 #
 #========================================================================
 #

--- a/configure.pl
+++ b/configure.pl
@@ -33,7 +33,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1335  USA
 #
 #========================================================================
 #

--- a/doc-src/BackupPC.pod
+++ b/doc-src/BackupPC.pod
@@ -2872,4 +2872,4 @@ General Public License for more details.
 
 You should have received a copy of the GNU General Public License in the
 LICENSE file along with this program; if not, write to the Free Software
-Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335 USA.

--- a/lib/BackupPC/Attrib.pm
+++ b/lib/BackupPC/Attrib.pm
@@ -26,7 +26,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1335  USA
 #
 #========================================================================
 #

--- a/lib/BackupPC/CGI/AdminOptions.pm
+++ b/lib/BackupPC/CGI/AdminOptions.pm
@@ -24,7 +24,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1335  USA
 #
 #========================================================================
 #

--- a/lib/BackupPC/CGI/Archive.pm
+++ b/lib/BackupPC/CGI/Archive.pm
@@ -24,7 +24,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1335  USA
 #
 #========================================================================
 #

--- a/lib/BackupPC/CGI/ArchiveInfo.pm
+++ b/lib/BackupPC/CGI/ArchiveInfo.pm
@@ -24,7 +24,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1335  USA
 #
 #========================================================================
 #

--- a/lib/BackupPC/CGI/Browse.pm
+++ b/lib/BackupPC/CGI/Browse.pm
@@ -24,7 +24,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1335  USA
 #
 #========================================================================
 #

--- a/lib/BackupPC/CGI/DirHistory.pm
+++ b/lib/BackupPC/CGI/DirHistory.pm
@@ -24,7 +24,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1335  USA
 #
 #========================================================================
 #

--- a/lib/BackupPC/CGI/EditConfig.pm
+++ b/lib/BackupPC/CGI/EditConfig.pm
@@ -24,7 +24,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1335  USA
 #
 #========================================================================
 #

--- a/lib/BackupPC/CGI/EmailSummary.pm
+++ b/lib/BackupPC/CGI/EmailSummary.pm
@@ -24,7 +24,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1335  USA
 #
 #========================================================================
 #

--- a/lib/BackupPC/CGI/GeneralInfo.pm
+++ b/lib/BackupPC/CGI/GeneralInfo.pm
@@ -24,7 +24,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1335  USA
 #
 #========================================================================
 #

--- a/lib/BackupPC/CGI/HostInfo.pm
+++ b/lib/BackupPC/CGI/HostInfo.pm
@@ -24,7 +24,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1335  USA
 #
 #========================================================================
 #

--- a/lib/BackupPC/CGI/LOGlist.pm
+++ b/lib/BackupPC/CGI/LOGlist.pm
@@ -24,7 +24,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1335  USA
 #
 #========================================================================
 #

--- a/lib/BackupPC/CGI/Lib.pm
+++ b/lib/BackupPC/CGI/Lib.pm
@@ -25,7 +25,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1335  USA
 #
 #========================================================================
 #

--- a/lib/BackupPC/CGI/Queue.pm
+++ b/lib/BackupPC/CGI/Queue.pm
@@ -24,7 +24,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1335  USA
 #
 #========================================================================
 #

--- a/lib/BackupPC/CGI/RSS.pm
+++ b/lib/BackupPC/CGI/RSS.pm
@@ -24,7 +24,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335  USA
 #
 #========================================================================
 #

--- a/lib/BackupPC/CGI/ReloadServer.pm
+++ b/lib/BackupPC/CGI/ReloadServer.pm
@@ -24,7 +24,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1335  USA
 #
 #========================================================================
 #

--- a/lib/BackupPC/CGI/Restore.pm
+++ b/lib/BackupPC/CGI/Restore.pm
@@ -24,7 +24,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1335  USA
 #
 #========================================================================
 #

--- a/lib/BackupPC/CGI/RestoreFile.pm
+++ b/lib/BackupPC/CGI/RestoreFile.pm
@@ -24,7 +24,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1335  USA
 #
 #========================================================================
 #

--- a/lib/BackupPC/CGI/RestoreInfo.pm
+++ b/lib/BackupPC/CGI/RestoreInfo.pm
@@ -24,7 +24,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1335  USA
 #
 #========================================================================
 #

--- a/lib/BackupPC/CGI/StartServer.pm
+++ b/lib/BackupPC/CGI/StartServer.pm
@@ -24,7 +24,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1335  USA
 #
 #========================================================================
 #

--- a/lib/BackupPC/CGI/StartStopBackup.pm
+++ b/lib/BackupPC/CGI/StartStopBackup.pm
@@ -24,7 +24,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1335  USA
 #
 #========================================================================
 #

--- a/lib/BackupPC/CGI/StopServer.pm
+++ b/lib/BackupPC/CGI/StopServer.pm
@@ -24,7 +24,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1335  USA
 #
 #========================================================================
 #

--- a/lib/BackupPC/CGI/Summary.pm
+++ b/lib/BackupPC/CGI/Summary.pm
@@ -24,7 +24,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1335  USA
 #
 #========================================================================
 #

--- a/lib/BackupPC/CGI/View.pm
+++ b/lib/BackupPC/CGI/View.pm
@@ -24,7 +24,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1335  USA
 #
 #========================================================================
 #

--- a/lib/BackupPC/Config/Meta.pm
+++ b/lib/BackupPC/Config/Meta.pm
@@ -24,7 +24,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1335  USA
 #
 #========================================================================
 #

--- a/lib/BackupPC/FileZIO.pm
+++ b/lib/BackupPC/FileZIO.pm
@@ -25,7 +25,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1335  USA
 #
 #========================================================================
 #

--- a/lib/BackupPC/Lib.pm
+++ b/lib/BackupPC/Lib.pm
@@ -25,7 +25,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1335  USA
 #
 #========================================================================
 #

--- a/lib/BackupPC/PoolWrite.pm
+++ b/lib/BackupPC/PoolWrite.pm
@@ -52,7 +52,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1335  USA
 #
 #========================================================================
 #

--- a/lib/BackupPC/Storage.pm
+++ b/lib/BackupPC/Storage.pm
@@ -25,7 +25,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1335  USA
 #
 #========================================================================
 #

--- a/lib/BackupPC/Storage/Text.pm
+++ b/lib/BackupPC/Storage/Text.pm
@@ -26,7 +26,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1335  USA
 #
 #========================================================================
 #

--- a/lib/BackupPC/View.pm
+++ b/lib/BackupPC/View.pm
@@ -27,7 +27,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1335  USA
 #
 #========================================================================
 #

--- a/lib/BackupPC/Xfer.pm
+++ b/lib/BackupPC/Xfer.pm
@@ -26,7 +26,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1335  USA
 #
 #========================================================================
 #

--- a/lib/BackupPC/Xfer/Archive.pm
+++ b/lib/BackupPC/Xfer/Archive.pm
@@ -25,7 +25,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1335  USA
 #
 #========================================================================
 #

--- a/lib/BackupPC/Xfer/Ftp.pm
+++ b/lib/BackupPC/Xfer/Ftp.pm
@@ -25,8 +25,8 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
-#   02111-1307 USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+#   02110-1335 USA
 #
 #
 #========================================================================

--- a/lib/BackupPC/Xfer/Protocol.pm
+++ b/lib/BackupPC/Xfer/Protocol.pm
@@ -25,7 +25,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1335  USA
 #
 #========================================================================
 #

--- a/lib/BackupPC/Xfer/Rsync.pm
+++ b/lib/BackupPC/Xfer/Rsync.pm
@@ -25,7 +25,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1335  USA
 #
 #========================================================================
 #

--- a/lib/BackupPC/Xfer/RsyncDigest.pm
+++ b/lib/BackupPC/Xfer/RsyncDigest.pm
@@ -25,7 +25,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1335  USA
 #
 #========================================================================
 #

--- a/lib/BackupPC/Xfer/RsyncFileIO.pm
+++ b/lib/BackupPC/Xfer/RsyncFileIO.pm
@@ -22,7 +22,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1335  USA
 #
 #========================================================================
 #

--- a/lib/BackupPC/Xfer/Smb.pm
+++ b/lib/BackupPC/Xfer/Smb.pm
@@ -25,7 +25,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1335  USA
 #
 #========================================================================
 #

--- a/lib/BackupPC/Xfer/Tar.pm
+++ b/lib/BackupPC/Xfer/Tar.pm
@@ -25,7 +25,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1335  USA
 #
 #========================================================================
 #

--- a/lib/BackupPC/Zip/FileMember.pm
+++ b/lib/BackupPC/Zip/FileMember.pm
@@ -29,7 +29,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1335  USA
 #
 #========================================================================
 #

--- a/makeDist
+++ b/makeDist
@@ -34,7 +34,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1335  USA
 #
 #========================================================================
 


### PR DESCRIPTION
to comply with http://www.fsf.org/about/contact/
    - during build for opensuse, some warnings from rpmlint appeared.
      The Free Software Foundation address changed, but was not updatet in the source.
      This patch updates the FSF address in all files.
      the License File was adapted to https://www.gnu.org/licenses/old-licenses/gpl-2.0.txt