### PR TITLE
feat(ClientWifiAlias): added an extra parameters to allow wifi backup

### DIFF
--- a/bin/BackupPC_dump
+++ b/bin/BackupPC_dump
@@ -491,37 +491,32 @@ foreach my $dir ( (
 #
 # Build the list of IP the check
 #
-my @validIPs = ();
+my %validIPs = ();
 
 if ( !$opts{d} ) {
     #
     # In the non-DHCP case, make sure the host can be looked up
     # via NS, or otherwise find the IP address via NetBios.
     #
-    if ( $Conf{ClientNameAlias} ne "" ) {
-        $host = $Conf{ClientNameAlias};
+    my @hostsToCheck = ();
+    if ( ref($Conf{ClientNameAlias}) eq 'ARRAY' ) {
+        push(@hostsToCheck, @{ $Conf{ClientNameAlias} });
+    } elsif ( $Conf{ClientNameAlias} ne "" ) {
+        push(@hostsToCheck, $Conf{ClientNameAlias});
     } else {
-        $host = $client;
+        push(@hostsToCheck, $client);
     }
 
-    $hostIP = FetchHostIP($host);
-    if ($hostIP) {
-        push(@validIPs, $hostIP);
-    }
-
-    if ( $Conf{ClientWifiAlias} ne "" ) {
-        #
-        # If ClientWifiAlias is set, do the same
-        #
-        $host = $Conf{ClientWifiAlias};
-        $hostIP = FetchHostIP($host);
+    foreach my $hostToCheck (@hostsToCheck) {
+        $hostIP = FetchHostIP($hostToCheck);
         if ($hostIP) {
-            push(@validIPs, $hostIP);
+            $validIPs{$hostToCheck} = $hostIP;
         }
     }
+
 } else {
     # In DHCP case the conversation was already made
-    push(@validIPs, $hostIP);
+    $validIPs{$host} = $hostIP;
 }
 
 #
@@ -530,7 +525,9 @@ if ( !$opts{d} ) {
 my $validIP;
 my $errMsg;
 
-foreach my $testIP (@validIPs) {
+foreach my $hostToCheck (keys(%validIPs)) {
+    my $testIP = $validIPs{$hostToCheck};
+
     my $delay = $bpc->CheckHostAlive($testIP);
     if ( $delay < 0 ) {
         print(LOG $bpc->timeStamp, "no ping response from $testIP\n");
@@ -547,6 +544,7 @@ foreach my $testIP (@validIPs) {
         next;
     }
     $validIP = $testIP;
+    $host = $hostToCheck;
     last;
 }
 
@@ -1987,7 +1985,10 @@ sub CorrectHostCheck
 {
     my($hostIP, $host) = @_;
     return if ( $hostIP eq $host && !$Conf{FixedIPNetBiosNameCheck}
-		|| $Conf{NmbLookupCmd} eq "" || $hostIP eq $Conf{ClientWifiAlias});
+		|| $Conf{NmbLookupCmd} eq "" );
+    if (ref($Conf{ClientNameAlias}) eq 'ARRAY') {
+        return if ( grep /^$hostIP$/, @{ $Conf{ClientNameAlias} } );
+    }
     my($netBiosHost, $netBiosUser) = $bpc->NetBiosInfoGet($hostIP);
     return "host $host has mismatching netbios name $netBiosHost"
 		if ( lc($netBiosHost) ne lc(substr($host, 0, 15)) );

--- a/bin/BackupPC_dump
+++ b/bin/BackupPC_dump
@@ -487,6 +487,12 @@ foreach my $dir ( (
     }
 }
 
+#
+#
+# Build the list of IP the check
+#
+my @validIPs = ();
+
 if ( !$opts{d} ) {
     #
     # In the non-DHCP case, make sure the host can be looked up
@@ -497,37 +503,60 @@ if ( !$opts{d} ) {
     } else {
         $host = $client;
     }
-    if ( !defined($bpc->getHostAddrInfo($host)) ) {
-        #
-        # Ok, NS doesn't know about it.  Maybe it is a NetBios name
-        # instead.
-        #
-	print("Name server doesn't know about $host; trying NetBios\n")
-			if ( $opts{v} );
-        if ( !defined($hostIP = $bpc->NetBiosHostIPFind($host)) ) {
-	    print(LOG $bpc->timeStamp, "Can't find host $host via netbios\n");
-            print("host not found\n");
-            exit(1);
-        }
-    } else {
-        $hostIP = $host;
+
+    $hostIP = FetchHostIP($host);
+    if ($hostIP) {
+        push(@validIPs, $hostIP);
     }
+
+    if ( $Conf{ClientWifiAlias} ne "" ) {
+        #
+        # If ClientWifiAlias is set, do the same
+        #
+        $host = $Conf{ClientWifiAlias};
+        $hostIP = FetchHostIP($host);
+        if ($hostIP) {
+            push(@validIPs, $hostIP);
+        }
+    }
+} else {
+    # In DHCP case the conversation was already made
+    push(@validIPs, $hostIP);
 }
 
 #
 # Check if $host is alive
 #
-my $delay = $bpc->CheckHostAlive($hostIP);
-if ( $delay < 0 ) {
-    print(LOG $bpc->timeStamp, "no ping response\n");
-    print("no ping response\n");
-    exit(1);
-} elsif ( $delay > $Conf{PingMaxMsec} ) {
-    printf(LOG "%sping too slow: %.4gmsec\n", $bpc->timeStamp, $delay);
-    printf("ping too slow: %.4gmsec (threshold is %gmsec)\n",
-                    $delay, $Conf{PingMaxMsec});
+my $validIP;
+my $errMsg;
+
+foreach my $testIP (@validIPs) {
+    my $delay = $bpc->CheckHostAlive($testIP);
+    if ( $delay < 0 ) {
+        print(LOG $bpc->timeStamp, "no ping response from $testIP\n");
+        print("no ping response from $testIP\n");
+        $errMsg = "no ping response\n";
+        next;
+        
+    } elsif ( $delay > $Conf{PingMaxMsec} ) {
+        printf(LOG "%sping too slow on $testIP %.4gmsec\n", $bpc->timeStamp, $delay);
+        printf("ping too slow on $testIP: %.4gmsec (threshold is %gmsec)\n",
+                        $delay, $Conf{PingMaxMsec});
+        $errMsg = sprintf("ping too slow: %.4gmsec (threshold is %gmsec)\n",
+                        $delay, $Conf{PingMaxMsec});
+        next;
+    }
+    $validIP = $testIP;
+    last;
+}
+
+if ( !$validIP ) {
+    print(LOG $bpc->timeStamp, $errMsg);
+    print($errMsg);
     exit(1);
 }
+
+$hostIP = $validIP;
 
 #
 # Make sure it is really the machine we expect (only for fixed addresses,
@@ -1958,11 +1987,34 @@ sub CorrectHostCheck
 {
     my($hostIP, $host) = @_;
     return if ( $hostIP eq $host && !$Conf{FixedIPNetBiosNameCheck}
-		|| $Conf{NmbLookupCmd} eq "" );
+		|| $Conf{NmbLookupCmd} eq "" || $hostIP eq $Conf{ClientWifiAlias});
     my($netBiosHost, $netBiosUser) = $bpc->NetBiosInfoGet($hostIP);
     return "host $host has mismatching netbios name $netBiosHost"
 		if ( lc($netBiosHost) ne lc(substr($host, 0, 15)) );
     return;
+}
+
+sub FetchHostIP
+{
+    my($host) = @_;
+    my $hostIP;
+
+    if ( !defined($bpc->getHostAddrInfo($host)) ) {
+        #
+        # Ok, NS doesn't know about it.  Maybe it is a NetBios name
+        # instead.
+        #
+	print("Name server doesn't know about $host; trying NetBios\n")
+			if ( $opts{v} );
+        if ( !defined($hostIP = $bpc->NetBiosHostIPFind($host)) ) {
+	    print(LOG $bpc->timeStamp, "Can't find host $host via netbios\n");
+            print("host $host not found\n");
+        }
+    } else {
+        $hostIP = $host;
+    }
+
+    return $hostIP;
 }
 
 #

--- a/bin/BackupPC_restore
+++ b/bin/BackupPC_restore
@@ -169,33 +169,59 @@ if ( $Conf{ClientNameAlias} ne "" ) {
 #
 # Find its IP address
 #
+my @validIPs = ();
+
 if ( $hostIP !~ /\d+\.\d+\.\d+\.\d+/ ) {
-    if ( !defined($bpc->getHostAddrInfo($host)) ) {
-	#
-	# Ok, NS doesn't know about it.  Maybe it is a NetBios name
-	# instead.
-	#
-	if ( !defined($hostIP = $bpc->NetBiosHostIPFind($host)) ) {
-	    $stat{hostError} = "Can't find host $host";
-	    exit(RestoreCleanup($client));
-	}
-    } else {
-	$hostIP = $host;
+
+    my $testIP = FetchHostIP($host);
+    if ( $testIP ) {
+        push(@validIPs, $testIP);
     }
 }
+
+if ( $Conf{ClientWifiAlias} ne "" ) {
+    #
+    # If ClientWifiAlias is set, do the same
+    #
+    my $test = $Conf{ClientWifiAlias};
+    my $testIP = FetchHostIP($test);
+    if ( $testIP ) {
+        push(@validIPs, $testIP);
+    }
+}
+
+if ( !@validIPs ) {
+    $stat{hostError} = "Can't find host $host";
+    exit(RestoreCleanup($client));
+}
+
 
 #
 # Check if $host is alive
 #
-my $delay = $bpc->CheckHostAlive($hostIP);
-if ( $delay < 0 ) {
-    $stat{hostError} = "no ping response from $host ($hostIP)";
-    exit(RestoreCleanup($client));
-} elsif ( $delay > $Conf{PingMaxMsec} ) {
-    $stat{hostError} = sprintf("ping too slow: %.4gmsec (max is %gmsec)\n",
-                    $delay, $Conf{PingMaxMsec});
+my $validIP;
+my $errMsg;
+
+foreach my $testIP (@validIPs) {
+    my $delay = $bpc->CheckHostAlive($testIP);
+    if ( $delay < 0 ) {
+        $errMsg = "no ping response from $host ($hostIP)";
+        next;
+    } elsif ( $delay > $Conf{PingMaxMsec} ) {
+        $errMsg = sprintf("ping too slow: %.4gmsec (max is %gmsec)\n",
+                        $delay, $Conf{PingMaxMsec});
+        next;
+    }
+    $validIP = $testIP;
+    last;
+}
+
+if ( !$validIP ) {
+    $stat{hostError} = $errMsg;
     exit(RestoreCleanup($client));
 }
+
+$hostIP = $validIP;
 
 #
 # Make sure it is really the machine we expect
@@ -462,12 +488,30 @@ exit(RestoreCleanup($client));
 ###########################################################################
 # Subroutines
 ###########################################################################
+sub FetchHostIP
+{
+    my($host) = @_;
+    my $hostIP;
+
+    if ( !defined($bpc->getHostAddrInfo($host)) ) {
+        #
+        # Ok, NS doesn't know about it.  Maybe it is a NetBios name
+        # instead.
+        #
+        if ( !defined($hostIP = $bpc->NetBiosHostIPFind($host)) ) {
+        }
+    } else {
+        $hostIP = $host;
+    }
+
+    return $hostIP;
+}
 
 sub CorrectHostCheck
 {
     my($hostIP, $host) = @_;
     return if ( $hostIP eq $host && !$Conf{FixedIPNetBiosNameCheck}
-		|| $Conf{NmbLookupCmd} eq "" );
+		|| $Conf{NmbLookupCmd} eq "" || $hostIP eq $Conf{ClientWifiAlias});
     my($netBiosHost, $netBiosUser) = $bpc->NetBiosInfoGet($hostIP);
     return "host $host has mismatching netbios name $netBiosHost"
             if ( lc($netBiosHost) ne lc(substr($host, 0, 15)) );

--- a/bin/BackupPC_restore
+++ b/bin/BackupPC_restore
@@ -160,39 +160,28 @@ alarm($Conf{ClientTimeout});
 #
 # See if the host name is aliased
 #
-if ( $Conf{ClientNameAlias} ne "" ) {
-    $host = $Conf{ClientNameAlias};
+my @hostsToCheck = ();
+if ( ref($Conf{ClientNameAlias}) eq 'ARRAY' ) {
+    push(@hostsToCheck, @{ $Conf{ClientNameAlias} });
+} elsif ( $Conf{ClientNameAlias} ne "" ) {
+    push(@hostsToCheck, $Conf{ClientNameAlias});
 } else {
-    $host = $client;
+    push(@hostsToCheck, $client);
 }
 
 #
 # Find its IP address
 #
-my @validIPs = ();
+my %validIPs = ();
 
 if ( $hostIP !~ /\d+\.\d+\.\d+\.\d+/ ) {
 
-    my $testIP = FetchHostIP($host);
-    if ( $testIP ) {
-        push(@validIPs, $testIP);
+    foreach my $hostToCheck (@hostsToCheck) {
+        $hostIP = FetchHostIP($hostToCheck);
+        if ($hostIP) {
+            $validIPs{$hostToCheck} = $hostIP;
+        }
     }
-}
-
-if ( $Conf{ClientWifiAlias} ne "" ) {
-    #
-    # If ClientWifiAlias is set, do the same
-    #
-    my $test = $Conf{ClientWifiAlias};
-    my $testIP = FetchHostIP($test);
-    if ( $testIP ) {
-        push(@validIPs, $testIP);
-    }
-}
-
-if ( !@validIPs ) {
-    $stat{hostError} = "Can't find host $host";
-    exit(RestoreCleanup($client));
 }
 
 
@@ -202,7 +191,9 @@ if ( !@validIPs ) {
 my $validIP;
 my $errMsg;
 
-foreach my $testIP (@validIPs) {
+foreach my $hostToCheck (keys(%validIPs)) {
+    my $testIP = $validIPs{$hostToCheck};
+
     my $delay = $bpc->CheckHostAlive($testIP);
     if ( $delay < 0 ) {
         $errMsg = "no ping response from $host ($hostIP)";
@@ -213,6 +204,7 @@ foreach my $testIP (@validIPs) {
         next;
     }
     $validIP = $testIP;
+    $host = $hostToCheck;
     last;
 }
 
@@ -511,7 +503,10 @@ sub CorrectHostCheck
 {
     my($hostIP, $host) = @_;
     return if ( $hostIP eq $host && !$Conf{FixedIPNetBiosNameCheck}
-		|| $Conf{NmbLookupCmd} eq "" || $hostIP eq $Conf{ClientWifiAlias});
+		|| $Conf{NmbLookupCmd} eq "" );
+    if (ref($Conf{ClientNameAlias}) eq 'ARRAY') {
+        return if ( grep /^$hostIP$/, @{ $Conf{ClientNameAlias} } );
+    }
     my($netBiosHost, $netBiosUser) = $bpc->NetBiosInfoGet($hostIP);
     return "host $host has mismatching netbios name $netBiosHost"
             if ( lc($netBiosHost) ne lc(substr($host, 0, 15)) );

--- a/conf/config.pl
+++ b/conf/config.pl
@@ -1798,29 +1798,17 @@ $Conf{UserCmdCheckStatus} = 0;
 #         $Conf{ClientNameAlias} = 'realHostName';
 #         $Conf{ClientNameAlias} = '192.1.1.15';
 #
+# It can also be an array, to allow backup of several IP addresses 
+# that refers to the same host (wired or wireless connection) eg:
+#
+#         $Conf{ClientNameAlias} = ['hostname-lan', 'hostname-wifi'];
+#
 # will cause the relevant smb/tar/rsync backup/restore commands to be
 # directed to realHostName, not the client name.
 #
 # Note: this setting doesn't work for hosts with DHCP set to 1.
 #
 $Conf{ClientNameAlias} = undef;
-
-#
-# Provide an alternative alias for machine that have both
-# wired and wifi connections. This allows to backup the same machine
-# over lan or wifi without too much extra configuration. As
-# ClientNameAlias, this should only be set in the per-PC config file.
-# The setting can be a hostname or IP address, eg:
-#
-#         $Conf{ClientWifiAlias} = 'realHostName-wifi';
-#         $Conf{ClientWifiAlias} = '192.1.1.15';
-#
-# will cause the relevant smb/tar/rsync backup/restore commands to be
-# directed to realHostName, not the client name.
-#
-# Note: this setting doesn't work for hosts with DHCP set to 1.
-#
-$Conf{ClientWifiAlias} = undef;
 
 ###########################################################################
 # Email reminders, status and messages

--- a/conf/config.pl
+++ b/conf/config.pl
@@ -1805,6 +1805,23 @@ $Conf{UserCmdCheckStatus} = 0;
 #
 $Conf{ClientNameAlias} = undef;
 
+#
+# Provide an alternative alias for machine that have both
+# wired and wifi connections. This allows to backup the same machine
+# over lan or wifi without too much extra configuration. As
+# ClientNameAlias, this should only be set in the per-PC config file.
+# The setting can be a hostname or IP address, eg:
+#
+#         $Conf{ClientWifiAlias} = 'realHostName-wifi';
+#         $Conf{ClientWifiAlias} = '192.1.1.15';
+#
+# will cause the relevant smb/tar/rsync backup/restore commands to be
+# directed to realHostName, not the client name.
+#
+# Note: this setting doesn't work for hosts with DHCP set to 1.
+#
+$Conf{ClientWifiAlias} = undef;
+
 ###########################################################################
 # Email reminders, status and messages
 # (can be overridden in the per-PC config.pl)


### PR DESCRIPTION
We use backuppc a lot but we are missing one feature.
We have a lots of laptop which connect randomly on wired connections or on wireless connections.

We try advanced DNS stuff but were unable to have a decent result.
Thus we made this patch.

Similar to ClientNameAlias, we implemented ClientWifiAlias.

What does it do ?

Instead a fetching a unique hostIP, we build an array of valid IP and loop on them.

I know it's far from being ready to merge but I'd like feedback on how to improve it :
- ClientWifiAlias : maybe make this an array ? or a better name ?

Cheers,