### PR TITLE
Remove SMB1 restriction

### DIFF
--- a/conf/config.pl
+++ b/conf/config.pl
@@ -948,7 +948,7 @@ $Conf{SmbClientPath} = '';
 #
 $Conf{SmbClientFullCmd} = '$smbClientPath \\\\$host\\$shareName'
 	    . ' $I_option -U $userName -E -d 1'
-            . ' -c tarmode\\ full -Tc$X_option - $fileList';
+            . ' -c tarmode\\ full -mSMB3 -Tc$X_option - $fileList';
 
 #
 # Command to run smbclient for an incremental dump.
@@ -962,7 +962,7 @@ $Conf{SmbClientFullCmd} = '$smbClientPath \\\\$host\\$shareName'
 #
 $Conf{SmbClientIncrCmd} = '$smbClientPath \\\\$host\\$shareName'
 	    . ' $I_option -U $userName -E -d 1'
-	    . ' -c tarmode\\ full -TcN$X_option $timeStampFile - $fileList';
+	    . ' -c tarmode\\ full -mSMB3 -TcN$X_option $timeStampFile - $fileList';
 
 #
 # Command to run smbclient for a restore.
@@ -980,7 +980,7 @@ $Conf{SmbClientIncrCmd} = '$smbClientPath \\\\$host\\$shareName'
 #
 $Conf{SmbClientRestoreCmd} = '$smbClientPath \\\\$host\\$shareName'
             . ' $I_option -U $userName -E -d 1'
-            . ' -c tarmode\\ full -Tx -';
+            . ' -c tarmode\\ full -mSMB3 -Tx -';
 
 ###########################################################################
 # Tar Configuration


### PR DESCRIPTION
SMBclient defaults to NT1 (SMB1) unless the user specifies a higher version. See the documentation of `smbclient`:
```
-m|--max-protocol protocol
   This allows the user to select the highest SMB protocol level that smbclient will use to connect to the server. By default this is
   set to NT1, which is the highest available SMB1 protocol. To connect using SMB2 or SMB3 protocol, use the strings SMB2 or SMB3
   respectively. Note that to connect to a Windows 2012 server with encrypted transport selecting a max-protocol of SMB3 is required.
```

I've tested the patch with a synology NAS (DSM6.1). This offers an option to specify the minimum SMB-version, that defaults to SMB1. Changing the configuration to SMB2, backuppc is unable to connect. (`Got fatal error during xfer (protocol negotiation failed: NT_STATUS_INVALID_NETWORK_RESPONSE)`)
This patch allows `smbclient` to use a higher version and newer SMB features making it working again. 

SMB3 is supported since samba 4.1 relaised in 2013. The main benefits regarding backups that I see are Multichanneling and Encryption. Multichanneling should improve the backup speed in case of higher latency between server and client.
SMB2 uses less commands per file improving the speed as well. 

This patch hasn't been tested with prior versions of samba 4.1.

Saving large shares with backuppc is faster but could also have other reasons (weekend).