### PR TITLE
Fix incorrect language code in config comments: zh_CH → zh_CN

### DIFF
--- a/conf/config.pl
+++ b/conf/config.pl
@@ -2030,7 +2030,7 @@ $Conf{RrdToolPath} = '';
 # Language to use.  See lib/BackupPC/Lang for the list of supported
 # languages, which include English (en), French (fr), Spanish (es),
 # German (de), Italian (it), Dutch (nl), Polish (pl), Portuguese
-# Brazilian (pt_br) and Chinese (zh_CH).
+# Brazilian (pt_br) and Chinese (zh_CN).
 #
 # Currently the Language setting applies to the CGI interface and email
 # messages sent to users.  Log files and other text are still in English.


### PR DESCRIPTION
* `zh_CH`: Chinese in Switzerland
* `zh_CN`: Chinese in China

`zh_CN` is the code actually used in BackupPC: https://github.com/backuppc/backuppc/blob/master/lib/BackupPC/Lang/zh_CN.pm