### PR TITLE
Increase start-up message verbosity

### DIFF
--- a/bin/BackupPC
+++ b/bin/BackupPC
@@ -359,7 +359,8 @@ sub Main_Initialize
     #
     # Report that we started, and update $Info.
     #
-    print(LOG $bpc->timeStamp, "BackupPC started, pid $$\n");
+    printf(LOG "%sBackupPC %s (Perl v%vd) started, pid %d\n",
+      $bpc->timeStamp, $bpc->{Version}, $^V, $$);
     $Info->{ConfigModTime} = $bpc->ConfigMTime();
     $Info->{pid} = $$;
     $Info->{startTime} = time;


### PR DESCRIPTION
printf is required to log version of Perl 5.8
https://perldoc.perl.org/perlvar.html#%24^V