### PR TITLE
Use Apache Digest auth instead of Basic auth

### DIFF
--- a/httpd/src/BackupPC.conf
+++ b/httpd/src/BackupPC.conf
@@ -7,27 +7,29 @@
 # Distributed with BackupPC version 3.1.1, released 22 Dec 2008.
 
 <Directory      __CGIDIR__ >
-
-#
-# This section tells apache which machines can access the interface.
-# You can change the allow line to allow access from your local
-# network, or comment out this region to allow access from all
-# machines.
-#
-order deny,allow
-deny from all
-allow from 127.0.0.1
-
-#
-# You can change the authorization method to LDAP or another method
-# besides htaccess here if you are so inclined.
-#
-AuthType Basic
-AuthUserFile __CONFDIR__/BackupPC.users
-AuthName "BackupPC Community Edition Administrative Interface"
-require valid-user
-
+    #
+    # This section tells apache which machines can access the interface.
+    # You can change the allow line to allow access from your local
+    # network, or comment out this region to allow access from all
+    # machines.
+    #
+    order deny,allow
+    deny from all
+    allow from 127.0.0.1
 </Directory>
+
+
+<Location "/">
+    # You can change the authorization method to LDAP or another method
+    # besides htaccess here if you are so inclined.
+    AuthType Digest
+    AuthName "BackupPC Community Edition Administrative Interface"
+    AuthDigestDomain "/" "http://__SERVERHOST__"
+    AuthDigestProvider file
+    Require valid-user
+    AuthUserFile "__CONFDIR__/BackupPC.users"
+    SetEnv R_ENV "__CGIDIR__"
+</Location>
 
 Alias           __IMAGEDIRURL__         __IMAGEDIR__
 ScriptAlias     /BackupPC_Admin         __CGIDIR__/BackupPC_Admin


### PR DESCRIPTION
This changes the configuration from using Auth Basic to Auth Digest. Auth Digest is more secure than Auth Basic as far as network transmission is concerned.

For some background see [[1]], [[2]], [[3]].

[1]: https://httpd.apache.org/docs/2.4/howto/auth.html
[2]: https://stackoverflow.com/questions/14911830/convert-passwords-from-htpasswd-to-htdigest
[3]: https://stackoverflow.com/questions/20910207/is-apache-digest-authentication-more-secure-or-than-basic-or-not