### PR TITLE
Fix BackupPC when rsync-bpc 3.1.2beta0 is used

### DIFF
--- a/bin/BackupPC
+++ b/bin/BackupPC
@@ -121,7 +121,7 @@ if ( $Conf{RsyncBackupPCPath} ne "" && -x $Conf{RsyncBackupPCPath} ) {
         exit(1);
     }
     my $version = "unknown";
-    $version = $1 if ( $output =~ /rsync_bpc\s+version\s+([\d.]+?)(?:\.?beta\d+)?\s+protocol/ );
+    $version = $1 if ( $output =~ /rsync_bpc\s+version\s+([\d.]+?)(\.?beta\d+)?\s+protocol/ );
     if ( $version eq "unknown" || version->parse($1) < version->parse($PackageVersion->{rsync_bpc}) ) {
         print(STDERR "BackupPC: rsync_bpc at $Conf{RsyncBackupPCPath} needs to be upgraded (got version $1; need >= $PackageVersion->{rsync_bpc}); exiting in 30s\n");
         sleep(30);

--- a/bin/BackupPC
+++ b/bin/BackupPC
@@ -121,7 +121,7 @@ if ( $Conf{RsyncBackupPCPath} ne "" && -x $Conf{RsyncBackupPCPath} ) {
         exit(1);
     }
     my $version = "unknown";
-    $version = $1 if ( $output =~ /rsync_bpc\s+version\s+([\d.]+?)(\.beta\d+)?\s+protocol/ );
+    $version = $1 if ( $output =~ /rsync_bpc\s+version\s+([\d.]+?)(?:\.?beta\d+)?\s+protocol/ );
     if ( $version eq "unknown" || version->parse($1) < version->parse($PackageVersion->{rsync_bpc}) ) {
         print(STDERR "BackupPC: rsync_bpc at $Conf{RsyncBackupPCPath} needs to be upgraded (got version $1; need >= $PackageVersion->{rsync_bpc}); exiting in 30s\n");
         sleep(30);


### PR DESCRIPTION
Latest version of rsync-bpc broke BackupPC, with the following error message:
```
BackupPC: rsync_bpc at /usr/local/bin/rsync_bpc needs to be upgraded (got version ; need >= 3.0.9.8); exiting in 30s
```

Indeed, `/usr/local/BackupPC/bin/BackupPC` will run at startup `rsync_bpc --version` at startup to check if a sufficiently up-to-date version is used.

To check the version, BackupPC will use this following regex (line 124):
```
/rsync_bpc\s+version\s+([\d.]+?)(\.beta\d+)?\s+protocol/
```

This regex is able to match a version like `3.1.2` or `3.1.2.beta0`. However, version 3.0.9.13 of rsync-bpc will return `3.1.2beta0`. Notice the absence of dot before `beta0`. So the version is not matched, and BackupPC hangs up.

This PR fixes that by replacing the faulty regex with this one:
```
/rsync_bpc\s+version\s+([\d.]+?)(?:\.?beta\d+)?\s+protocol/
```

This will match `3.1.2`, `3.1.2.beta0` and `3.1.2beta0`, making the parsing stronger (and we also avoid to capture `beta\d+`, as it is not needed). However, I think a standard and stable version of rsync_bpc should be published for the long-term, but this is outside of this PR scope.