### PR TITLE
Make tar Xfer compatible with FreeBSD tar

### DIFF
--- a/lib/BackupPC/Xfer/Tar.pm
+++ b/lib/BackupPC/Xfer/Tar.pm
@@ -209,7 +209,7 @@ sub readOutput
         if ( /^Total bytes (written|read): / ) {
             $t->{XferLOG}->write(\"$_\n") if ( $t->{logLevel} >= 1 );
             $t->{xferOK} = 1;
-        } elsif ( /^\./ ) {
+        } elsif ( /^(a )?\./ ) {
             $t->{XferLOG}->write(\"$_\n") if ( $t->{logLevel} >= $logFileThres );
             $t->{fileCnt}++;
         } else {


### PR DESCRIPTION
FreeBSD/pfsense's tar outputs a slightly different format, making BackupPC think that no files were dumped, when in fact they were.

GNU tar: `./newfile.txt`
FreeBSD tar: `a ./newfile.txt`

More details and credits to Sebastiaan van Erk: https://sourceforge.net/p/backuppc/mailman/message/34909672/