### PR TITLE
Prevent incrDuration metric value being undefined

### DIFF
--- a/lib/BackupPC/CGI/Metrics.pm
+++ b/lib/BackupPC/CGI/Metrics.pm
@@ -117,7 +117,7 @@ sub action
         my($fullAge, $fullCount, $fullDuration, $fullRate, $fullSize, $incrAge, $incrCount, $incrDuration);
 
         $fullCount = $incrCount = 0;
-        $fullAge   = $incrAge   = -1;
+        $fullAge   = $incrAge   = $fullDuration = $incrDuration = -1;
 
         my @Backups = $bpc->BackupInfoRead($host);
         $bpc->ConfigRead($host);


### PR DESCRIPTION
When a a host doesn't have an incremental backup the prometheus metric eported resulted in an metric line without a value.