### PR TITLE
Add ServerAliveInterval to $Conf{RsyncSshArgs}

### DIFF
--- a/conf/config.pl
+++ b/conf/config.pl
@@ -1229,7 +1229,7 @@ $Conf{RsyncBackupPCPath} = "";
 #
 # This setting only matters if $Conf{XferMethod} = 'rsync'.
 #
-$Conf{RsyncSshArgs} = ['-e', '$sshPath -l root'];
+$Conf{RsyncSshArgs} = ['-e', '$sshPath -l root -o ServerAliveInterval=60'];
 
 #
 # Share name to backup.  For $Conf{XferMethod} = "rsync" this should


### PR DESCRIPTION
When rsync over ssh crosses a firewall (which is fairly often) and a large file is being processed, rsync can take quite some time calculating the hash values for all chunks in the file. During this time the ssh connection sits idle and this can cause the firewall to forget all about the connection and drop it. To resolve this ssh can send a NULL packet ever so often to keep the connection alive.

It gave us major headaches to find the root cause of this problem. Please consider adding this to the default backuppc config.pl