### PR TITLE
[Test] Add CircleCI tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,79 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: buildpack-deps:sid
+    steps:
+      - checkout
+
+      - restore_cache:
+          key: v2-perl_modules-{{ checksum "cpanfile" }}
+      - run:
+          name: Installing cpanm
+          command: 'curl -L https://cpanmin.us | perl - App::cpanminus'
+      - run:
+          name: Installing CPAN dependencies
+          command: cpanm --quiet --installdeps --notest .
+      - save_cache:
+          key: v2-perl_modules-{{ checksum "cpanfile" }}
+          paths:
+            - ~/perl5
+
+      - run:
+          name: Adding backuppc user
+          command: useradd -s /usr/sbin/nologin backuppc
+      - run:
+          name: Building BackupPC distribution
+          command: ./makeDist --version HEAD
+      - run:
+          name: Installing BackupPC
+          command: |
+            cd ./dist/BackupPC-HEAD
+            ./configure.pl --batch
+      - run:
+          name: Starting BackupPC
+          command: su -m -s /bin/sh backuppc -c '/usr/local/BackupPC/bin/BackupPC -d'
+      - run:
+          name: Checking BackupPC log
+          command: >-
+            cat /var/log/BackupPC/LOG;
+            set +e;
+            egrep -v '[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}(
+            Reading hosts file|
+            BackupPC HEAD \(Perl v5\.[0-9]{1,2}\.[0-9]\) started, pid [0-9]+|
+            Next wakeup is [0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2})$'
+            /var/log/BackupPC/LOG; test $? -eq 1
+
+  tidy:
+    docker:
+      - image: buildpack-deps:sid
+    steps:
+      - checkout
+
+      - restore_cache:
+          key: v2-tidyall_dependencies
+      - run:
+          name: Installing cpanm
+          command: 'curl -L https://cpanmin.us | perl - App::cpanminus'
+      - run:
+          name: Installing CPAN dependencies
+          command: |
+            cpanm --quiet --notest \
+              Code::TidyAll
+      - save_cache:
+          key: v2-tidyall_dependencies
+          paths:
+            - ~/perl5
+
+      - run:
+          name: Running tidyall
+          command: |
+            tidyall --version
+            tidyall -a --check-only || ( tidyall -a && git diff && false )
+
+workflows:
+  version: 2
+  build_and_tidy:
+    jobs:
+      - build
+      - tidy

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Code::TidyAll
+/.tidyall.d/

--- a/.tidyallrc
+++ b/.tidyallrc
@@ -1,0 +1,17 @@
+; Run "tidyall -a" to process all files.
+; Run "tidyall -g" to process all added or modified files in the current git working directory.
+
+[PodChecker]
+select = **/*.{pl,pm,pod}
+
+;[PodSpell]
+;select = **/*.{pl,pm,pod}
+;argv = aspell --lang=en list
+
+;[PodTidy]
+;select = **/*.{pl,pm,pod}
+
+;[Test::Vars]
+;select = **/*.{pl,pm,t}
+;select = makeDist
+;select = makePatch


### PR DESCRIPTION
  - build test
  - podchecker

Now Travis CI tests are waiting in the queue about half an hour before starting the build. It is too long. CircleCI is faster and it's queue times are minimal.  Testing various Perl versions in CircleCI is complicated, so I propose to keep it in Travis CI since Travis CI supports Perl natively.

I've created CircleCI configuration for one build test on preinstalled Perl version and `podchecker` test. I am planning to add `podtidy`, `Test::Vars` and move `pre-commit` tests from Travis CI.

I've  used `tidyall` to run `podchecker` just because I am not familiar with `pre-commit` (I guess we should write own hook for `podchecker`) but with `tidyall` it is simple and straightforward .