### PR TITLE
[Test] CircleCI: Build on multiple Perl versions and add pre-commit job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,6 @@
 version: 2.1
+orbs:
+  linter: thekevjames/linter@1.1.15
 jobs:
   build:
     parameters:
@@ -84,4 +86,9 @@ workflows:
               #
               # Available Docker images are listed here: https://hub.docker.com/_/perl
               perl-version: ["5.32", "5.30", "5.28", "5.26", "5.24", "5.22", "5.20"]
+      - linter/pre-commit:
+          pre-steps:
+            - run:
+                name: Force colored Git output
+                command: git config --global color.ui always
       - tidy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,26 +51,43 @@ jobs:
     docker:
       - image: perl:latest
     steps:
+      - run:
+          name: Exporting env vars
+          command: |
+            cat >> $BASH_ENV \<<EOF
+            export PATH=$PATH:$HOME/perl5/bin
+            export PERL_CPANM_OPT=--local-lib=$HOME/perl5
+            export PERL5LIB=$HOME/perl5/lib/perl5:$PERL5LIB
+            EOF
       - checkout
 
       - restore_cache:
-          key: v4-tidyall_dependencies
+          key: v8-tidyall_dependencies
       - run:
           name: Installing CPAN dependencies
           command: |
             cpanm --quiet --notest \
-              Code::TidyAll
+              Code::TidyAll \
+              Pod::Tidy
       - save_cache:
-          key: v4-tidyall_dependencies
+          key: v8-tidyall_dependencies
           paths:
-            - /usr/local/lib/perl5/site_perl
-            - /usr/local/bin/tidyall
+            - ~/perl5
 
       - run:
           name: Running tidyall
           command: |
             tidyall --version
-            tidyall -a --check-only || ( tidyall -a && git diff && false )
+            tidyall -a --check-only
+      - run:
+          name: Tidiyng files
+          command: tidyall -a
+          when: on_fail
+      - run:
+          name: git diff
+          # Exit status is forced to expand command output in job log
+          command: tidyall -a && git --no-pager diff --color && false
+          when: on_fail
 
 workflows:
   build_and_tidy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,6 +106,8 @@ workflows:
       - linter/pre-commit:
           pre-steps:
             - run:
-                name: Force colored Git output
-                command: git config --global color.ui always
+                name: Force colored Git output and disable pager
+                command: |
+                  git config --global core.pager ''
+                  git config --global color.ui always
       - tidy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,23 +1,24 @@
-version: 2
+version: 2.1
 jobs:
   build:
+    parameters:
+      perl-version:
+        default: "latest"
+        type: string
     docker:
-      - image: buildpack-deps:sid
+      - image: perl:<< parameters.perl-version >>
     steps:
       - checkout
 
       - restore_cache:
-          key: v2-perl_modules-{{ checksum "cpanfile" }}
-      - run:
-          name: Installing cpanm
-          command: 'curl -L https://cpanmin.us | perl - App::cpanminus'
+          key: v3-perl_modules-<< parameters.perl-version >>-{{ checksum "cpanfile" }}
       - run:
           name: Installing CPAN dependencies
           command: cpanm --quiet --installdeps --notest .
       - save_cache:
-          key: v2-perl_modules-{{ checksum "cpanfile" }}
+          key: v3-perl_modules-<< parameters.perl-version >>-{{ checksum "cpanfile" }}
           paths:
-            - ~/perl5
+            - /usr/local/lib/perl5/site_perl
 
       - run:
           name: Adding backuppc user
@@ -46,24 +47,22 @@ jobs:
 
   tidy:
     docker:
-      - image: buildpack-deps:sid
+      - image: perl:latest
     steps:
       - checkout
 
       - restore_cache:
-          key: v2-tidyall_dependencies
-      - run:
-          name: Installing cpanm
-          command: 'curl -L https://cpanmin.us | perl - App::cpanminus'
+          key: v4-tidyall_dependencies
       - run:
           name: Installing CPAN dependencies
           command: |
             cpanm --quiet --notest \
               Code::TidyAll
       - save_cache:
-          key: v2-tidyall_dependencies
+          key: v4-tidyall_dependencies
           paths:
-            - ~/perl5
+            - /usr/local/lib/perl5/site_perl
+            - /usr/local/bin/tidyall
 
       - run:
           name: Running tidyall
@@ -72,8 +71,17 @@ jobs:
             tidyall -a --check-only || ( tidyall -a && git diff && false )
 
 workflows:
-  version: 2
   build_and_tidy:
     jobs:
-      - build
+      - build:
+          matrix:
+            parameters:
+              # Perl version matrix follows versions still in use by popular
+              # distributions such as Debian or Ubuntu, see:
+              # - https://www.cpan.org/src/
+              # - https://packages.debian.org/search?keywords=perl
+              # - https://packages.ubuntu.com/search?keywords=perl
+              #
+              # Available Docker images are listed here: https://hub.docker.com/_/perl
+              perl-version: ["5.32", "5.30", "5.28", "5.26", "5.24", "5.22", "5.20"]
       - tidy

--- a/.tidyallrc
+++ b/.tidyallrc
@@ -8,8 +8,8 @@ select = **/*.{pl,pm,pod}
 ;select = **/*.{pl,pm,pod}
 ;argv = aspell --lang=en list
 
-;[PodTidy]
-;select = **/*.{pl,pm,pod}
+[PodTidy]
+select = **/*.{pl,pm,pod}
 
 ;[Test::Vars]
 ;select = **/*.{pl,pm,t}

--- a/configure.pl
+++ b/configure.pl
@@ -1236,12 +1236,12 @@ configure.pl [options]
 =head1 DESCRIPTION
 
 configure.pl is a script that is used to install or upgrade a BackupPC
-installation.  It is usually run interactively without arguments.  It
-also supports a batch mode where all the options can be specified
-via the command-line.
+installation.  It is usually run interactively without arguments.  It also
+supports a batch mode where all the options can be specified via the
+command-line.
 
-For upgrading BackupPC you need to make sure that BackupPC is not
-running prior to running configure.pl.
+For upgrading BackupPC you need to make sure that BackupPC is not running prior
+to running configure.pl.
 
 Typically configure.pl needs to run as the super user (root).
 
@@ -1251,27 +1251,26 @@ Typically configure.pl needs to run as the super user (root).
 
 =item B<--batch>
 
-Run configure.pl in batch mode.  configure.pl will run without
-prompting the user.  The other command-line options are used
-to specify the settings that the user is usually prompted for.
+Run configure.pl in batch mode.  configure.pl will run without prompting the
+user.  The other command-line options are used to specify the settings that the
+user is usually prompted for.
 
 =item B<--backuppc-user=USER>
 
-Specify the BackupPC user name that owns all the BackupPC
-files and runs the BackupPC programs.  Default is backuppc.
+Specify the BackupPC user name that owns all the BackupPC files and runs the
+BackupPC programs.  Default is backuppc.
 
 =item B<--bin-path PROG=PATH>
 
-Specify the path for various external programs that BackupPC
-uses.  Several --bin-path options may be specified.  configure.pl
-usually finds sensible defaults based on searching the PATH.
-The format is:
+Specify the path for various external programs that BackupPC uses.  Several
+--bin-path options may be specified.  configure.pl usually finds sensible
+defaults based on searching the PATH. The format is:
 
     --bin-path PROG=PATH
 
-where PROG is one of perl, tar, smbclient, nmblookup, rsync, rsync_bpc,
-ping, df, ssh, sendmail, hostname, split, par2, cat, gzip, bzip2 and
-PATH is that full path to that program.
+where PROG is one of perl, tar, smbclient, nmblookup, rsync, rsync_bpc, ping,
+df, ssh, sendmail, hostname, split, par2, cat, gzip, bzip2 and PATH is that
+full path to that program.
 
 Examples
 
@@ -1283,15 +1282,15 @@ Set the configuration compression level to N.  Default is 3.
 
 =item B<--config-dir CONFIG_DIR>
 
-Configuration directory.  Defaults to /etc/BackupPC with FHS.
-Automatically extracted from --config-path for existing installations.
+Configuration directory.  Defaults to /etc/BackupPC with FHS. Automatically
+extracted from --config-path for existing installations.
 
 =item B<--config-override name=value>
 
-Override a specific configuration parameter.  Can be specified multiple
-times.  "Name" is the parameter name and "value" is the exact text that
-is inserted in the config.pl file (so you will need to escape quotes etc).
-For example, to override $Conf{ServerHost} you would specify:
+Override a specific configuration parameter.  Can be specified multiple times.
+"Name" is the parameter name and "value" is the exact text that is inserted in
+the config.pl file (so you will need to escape quotes etc). For example, to
+override $Conf{ServerHost} you would specify:
 
     --config-override ServerHost=\"myhost\"
 
@@ -1299,10 +1298,10 @@ For example, to override $Conf{ServerHost} you would specify:
 
 Do not install anything else, just create or update the config.pl and hosts
 configuration files. This option can be used for automatic update of the
-configuration after upgrading BackupPC using a package. With this option enabled
-the configure.pl can be used separately from the rest of BackupPC distribution
-files. In this case you should tell it where to look for installed BackupPC
-files.
+configuration after upgrading BackupPC using a package. With this option
+enabled the configure.pl can be used separately from the rest of BackupPC
+distribution files. In this case you should tell it where to look for installed
+BackupPC files.
 
 So you will need to define the PERL5LIB environmental variable, for example for
 Bourne shell:
@@ -1316,27 +1315,25 @@ or specify the path via Perl -I flag:
 
 =item B<--config-path CONFIG_PATH>
 
-Path to the existing config.pl configuration file for BackupPC.
-This option should be specified for batch upgrades to an
-existing installation.  The option should be omitted when
-doing a batch new install.
+Path to the existing config.pl configuration file for BackupPC. This option
+should be specified for batch upgrades to an existing installation.  The option
+should be omitted when doing a batch new install.
 
 =item B<--cgi-dir CGI_DIR>
 
-Path to Apache's cgi-bin directory where the BackupPC_Admin
-script will be installed.  This option only needs to be
-specified for a batch new install.
+Path to Apache's cgi-bin directory where the BackupPC_Admin script will be
+installed.  This option only needs to be specified for a batch new install.
 
 =item B<--scgi-port N>
 
-Numeric TCP port that is used for communication between Apache
-and BackupPC_Admin_SCGI.  A negative value disables SCGI.
+Numeric TCP port that is used for communication between Apache and
+BackupPC_Admin_SCGI.  A negative value disables SCGI.
 
 =item B<--data-dir DATA_DIR>
 
-Path to the BackupPC data directory.  This is where all the backup
-data is stored, and it should be on a large file system. This option
-only needs to be specified for a batch new install.
+Path to the BackupPC data directory.  This is where all the backup data is
+stored, and it should be on a large file system. This option only needs to be
+specified for a batch new install.
 
 Example:
 
@@ -1344,21 +1341,20 @@ Example:
 
 =item B<--dest-dir DEST_DIR>
 
-An optional prefix to apply to all installation directories.  Usually this
-is not needed, but is used by package creators, or certain auto-installers
-that like to stage an install in a temporary directory, and then copy
-the files to their real destination.  This option can be used to specify
-the target directory prefix.  If you specify this option any existing
-installation should be ignored.  Note that BackupPC won't run correctly if
-you try to run it from below the --dest-dir directory, since all the paths
-are set assuming BackupPC is installed in the intended final locations.
+An optional prefix to apply to all installation directories.  Usually this is
+not needed, but is used by package creators, or certain auto-installers that
+like to stage an install in a temporary directory, and then copy the files to
+their real destination.  This option can be used to specify the target
+directory prefix.  If you specify this option any existing installation should
+be ignored.  Note that BackupPC won't run correctly if you try to run it from
+below the --dest-dir directory, since all the paths are set assuming BackupPC
+is installed in the intended final locations.
 
 =item B<--fhs>
 
-Use locations specified by the Filesystem Hierarchy Standard
-for installing BackupPC.  This is enabled by default for new
-installations.  To use the pre-3.0 installation locations,
-specify --no-fhs.
+Use locations specified by the Filesystem Hierarchy Standard for installing
+BackupPC.  This is enabled by default for new installations.  To use the
+pre-3.0 installation locations, specify --no-fhs.
 
 =item B<--help|?>
 
@@ -1366,15 +1362,15 @@ Print a brief help message and exits.
 
 =item B<--hostname HOSTNAME>
 
-Host name (this machine's name) on which BackupPC is being installed.
-This option only needs to be specified for a batch new install.
+Host name (this machine's name) on which BackupPC is being installed. This
+option only needs to be specified for a batch new install.
 
 =item B<--html-dir HTML_DIR>
 
-Path to an Apache html directory where various BackupPC image files
-and the CSS files will be installed.  This is typically a directory
-below Apache's DocumentRoot directory.  This option only needs to be
-specified for a batch new install.
+Path to an Apache html directory where various BackupPC image files and the CSS
+files will be installed.  This is typically a directory below Apache's
+DocumentRoot directory.  This option only needs to be specified for a batch new
+install.
 
 Example:
 
@@ -1383,8 +1379,8 @@ Example:
 =item B<--html-dir-url URL>
 
 The URL (without http://hostname) required to access the BackupPC html
-directory specified with the --html-dir option.  This option only needs
-to be specified for a batch new install.
+directory specified with the --html-dir option.  This option only needs to be
+specified for a batch new install.
 
 Example:
 
@@ -1392,9 +1388,8 @@ Example:
 
 =item B<--install-dir INSTALL_DIR>
 
-Installation directory for BackupPC scripts, libraries, and
-documentation.  This option only needs to be specified for a
-batch new install.
+Installation directory for BackupPC scripts, libraries, and documentation. This
+option only needs to be specified for a batch new install.
 
 Example:
 
@@ -1414,18 +1409,17 @@ Run directory.  Defaults to /var/run/BackupPC with FHS.
 
 =item B<--set-perms>
 
-When installing files and creating directories, chown them to
-the BackupPC user and chmod them too.  This is enabled by default.
-To disable (for example, if staging a destination directory)
-then specify --no-set-perms.
+When installing files and creating directories, chown them to the BackupPC user
+and chmod them too.  This is enabled by default. To disable (for example, if
+staging a destination directory) then specify --no-set-perms.
 
 =item B<--uid-ignore>
 
-configure.pl verifies that the script is being run as the super user
-(root).  Without the --uid-ignore option, in batch mode the script will
-exit with an error if not run as the super user, and in interactive mode
-the user will be prompted.  Specifying this option will cause the script
-to continue even if the user id is not root.
+configure.pl verifies that the script is being run as the super user (root).
+Without the --uid-ignore option, in batch mode the script will exit with an
+error if not run as the super user, and in interactive mode the user will be
+prompted.  Specifying this option will cause the script to continue even if the
+user id is not root.
 
 =back
 
@@ -1435,8 +1429,8 @@ For a standard interactive install, run without arguments:
 
     configure.pl
 
-For a batch new install you need to specify answers to all the
-questions that are normally prompted:
+For a batch new install you need to specify answers to all the questions that
+are normally prompted:
 
     configure.pl                                   \
         --batch                                    \
@@ -1447,8 +1441,8 @@ questions that are normally prompted:
         --html-dir-url /BackupPC                   \
         --install-dir /usr/local/BackupPC
 
-For a batch upgrade, you only need to specify the path to the
-configuration file:
+For a batch upgrade, you only need to specify the path to the configuration
+file:
 
     configure.pl --batch --config-path /data/BackupPC/conf/config.pl
 
@@ -1460,9 +1454,9 @@ Craig Barratt <cbarratt@users.sourceforge.net>
 
 Copyright (C) 2001-2020  Craig Barratt.
 
-This program is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 2 of the License, or
-(at your option) any later version.
+This program is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation; either version 2 of the License, or (at your option) any later
+version.
 
 =cut

--- a/doc-src/BackupPC.pod
+++ b/doc-src/BackupPC.pod
@@ -2,20 +2,20 @@
 
 =head1 BackupPC Introduction
 
-This documentation describes BackupPC version __VERSION__,
-released on __RELEASEDATE__.
+This documentation describes BackupPC version __VERSION__, released on
+__RELEASEDATE__.
 
 =head2 Overview
 
-BackupPC is a high-performance, enterprise-grade system for backing up
-Unix, Linux, WinXX, and MacOSX PCs, desktops and laptops to a server's
-disk.  BackupPC is highly configurable and easy to install and maintain.
+BackupPC is a high-performance, enterprise-grade system for backing up Unix,
+Linux, WinXX, and MacOSX PCs, desktops and laptops to a server's disk. BackupPC
+is highly configurable and easy to install and maintain.
 
-Given the ever decreasing cost of disks and raid systems, it is now
-practical and cost effective to backup a large number of machines onto
-a server's local disk or network storage.  For some sites this might be
-the complete backup solution.  For other sites additional permanent
-archives could be created by periodically backing up the server to tape.
+Given the ever decreasing cost of disks and raid systems, it is now practical
+and cost effective to backup a large number of machines onto a server's local
+disk or network storage.  For some sites this might be the complete backup
+solution.  For other sites additional permanent archives could be created by
+periodically backing up the server to tape.
 
 Features include:
 
@@ -23,72 +23,64 @@ Features include:
 
 =item *
 
-A clever pooling scheme minimizes disk storage and disk I/O.
-Identical files across multiple backups of the same or different PC
-are stored only once, resulting in substantial savings in disk storage
-and disk writes.
+A clever pooling scheme minimizes disk storage and disk I/O. Identical files
+across multiple backups of the same or different PC are stored only once,
+resulting in substantial savings in disk storage and disk writes.
 
 =item *
 
-Compression provides additional reductions in storage, depending
-on the type of data being backed up. The CPU impact of compression
-is low since only new files (those not already in the pool) need
-to be compressed.
+Compression provides additional reductions in storage, depending on the type of
+data being backed up. The CPU impact of compression is low since only new files
+(those not already in the pool) need to be compressed.
 
 =item *
 
-A powerful http/cgi user interface allows administrators to view
-the current status, edit configuration, add/delete hosts, view log
-files, and allows users to initiate and cancel backups and browse
-and restore files from backups.
+A powerful http/cgi user interface allows administrators to view the current
+status, edit configuration, add/delete hosts, view log files, and allows users
+to initiate and cancel backups and browse and restore files from backups.
 
 =item *
 
-The http/cgi user interface has internationalization (i18n) support,
-currently providing English, French, German, Spanish, Italian,
-Dutch, Polish, Portuguese-Brazilian, Chinese, Polish, Czech,
-Japanese, Ukrainian, and Russian.
+The http/cgi user interface has internationalization (i18n) support, currently
+providing English, French, German, Spanish, Italian, Dutch, Polish,
+Portuguese-Brazilian, Chinese, Polish, Czech, Japanese, Ukrainian, and Russian.
 
 =item *
 
-No client-side software is needed. On WinXX the standard smb
-protocol is used to extract backup data. On linux, unix or MacOSX
-clients, rsync, tar (over ssh/rsh/nfs) or ftp is used to extract
-backup data.  Alternatively, rsync can also be used on WinXX (using
-cygwin), since rsync provides for efficient transfers and allows
-incremental backups to detect almost all changes.
+No client-side software is needed. On WinXX the standard smb protocol is used
+to extract backup data. On linux, unix or MacOSX clients, rsync, tar (over
+ssh/rsh/nfs) or ftp is used to extract backup data.  Alternatively, rsync can
+also be used on WinXX (using cygwin), since rsync provides for efficient
+transfers and allows incremental backups to detect almost all changes.
 
 =item *
 
-Flexible restore options.  Single files can be downloaded from
-any backup directly from the CGI interface.  Zip or Tar archives
-for selected files or directories from any backup can also be
-downloaded from the CGI interface.  Finally, direct restore to
-the client machine (using smb or tar) for selected files or
-directories is also supported from the CGI interface.
+Flexible restore options.  Single files can be downloaded from any backup
+directly from the CGI interface.  Zip or Tar archives for selected files or
+directories from any backup can also be downloaded from the CGI interface.
+Finally, direct restore to the client machine (using smb or tar) for selected
+files or directories is also supported from the CGI interface.
 
 =item *
 
-BackupPC supports mobile environments where laptops are only
-intermittently connected to the network and have dynamic IP addresses
-(DHCP).  Configuration settings allow machines connected via slower WAN
-connections (eg: dial up, DSL, cable) to not be backed up, even if they
-use the same fixed or dynamic IP address as when they are connected
-directly to the LAN.
+BackupPC supports mobile environments where laptops are only intermittently
+connected to the network and have dynamic IP addresses (DHCP).  Configuration
+settings allow machines connected via slower WAN connections (eg: dial up, DSL,
+cable) to not be backed up, even if they use the same fixed or dynamic IP
+address as when they are connected directly to the LAN.
 
 =item *
 
-Flexible configuration parameters allow multiple backups to be performed
-in parallel, specification of which shares to backup, which directories
-to backup or not backup, various schedules for full and incremental
-backups, schedules for email reminders to users and so on.  Configuration
-parameters can be set system-wide or also on a per-PC basis.
+Flexible configuration parameters allow multiple backups to be performed in
+parallel, specification of which shares to backup, which directories to backup
+or not backup, various schedules for full and incremental backups, schedules
+for email reminders to users and so on.  Configuration parameters can be set
+system-wide or also on a per-PC basis.
 
 =item *
 
-Users are sent periodic email reminders if their PC has not
-recently been backed up.  Email content, timing and policies
-are configurable.
+Users are sent periodic email reminders if their PC has not recently been
+backed up.  Email content, timing and policies are configurable.
 
 =item *
 
@@ -98,9 +90,8 @@ BackupPC is Open Source software hosted by GitHub.
 
 =head2 BackupPC 4.0
 
-This is the first release of 4.0, which is a significant rewrite of
-BackupPC.  This section provides a short overview of the changes and
-features in 4.0.
+This is the first release of 4.0, which is a significant rewrite of BackupPC.
+This section provides a short overview of the changes and features in 4.0.
 
 Here's a short summary of what has changed in V4:
 
@@ -109,43 +100,45 @@ Here's a short summary of what has changed in V4:
 =item *
 
 No use of hardlinks (except temporarily to do atomic renames).  Reference
-counting is handled at the application level in a batch manner (hardlinks
-will still remain for any legacy V3 backups).
+counting is handled at the application level in a batch manner (hardlinks will
+still remain for any legacy V3 backups).
 
 =item *
 
-Backups are stored as "reverse deltas" - the most recent backup is always filled
-and older backups are reconstituted by merging all the deltas starting with the
-nearest future filled backup and working backwards.
+Backups are stored as "reverse deltas" - the most recent backup is always
+filled and older backups are reconstituted by merging all the deltas starting
+with the nearest future filled backup and working backwards.
 
-This is the opposite of V3 where incrementals are stored as "forward deltas"
-to a prior backup (typically the last full backup or prior lower-level
-incremental backup, or the last full in the case of rsync).
+This is the opposite of V3 where incrementals are stored as "forward deltas" to
+a prior backup (typically the last full backup or prior lower-level incremental
+backup, or the last full in the case of rsync).
 
 =item *
 
 Since the most recent backup is filled, viewing/restoring that backup (which is
-the most common backup used) doesn't require merging any deltas from other backups.
+the most common backup used) doesn't require merging any deltas from other
+backups.
 
 =item *
 
-The concepts of incr/full backups and unfilled/filled storage are decoupled.  The most
-recent backup is always filled.  By default, for the remaining backups, full backups
-are filled and incremental backups are unfilled, but that is configurable.
+The concepts of incr/full backups and unfilled/filled storage are decoupled.
+The most recent backup is always filled.  By default, for the remaining
+backups, full backups are filled and incremental backups are unfilled, but that
+is configurable.
 
 =item *
 
-Uses full-file MD5 digests, which are stored in the directory attrib
-files.  Each backup directory only contains an empty attrib file whose
-name includes its own MD5 digest, which is used to look up the attrib
-file's contents in the pool.  In turn, that file contains the metadata
-for every file in that directory, including each files's MD5 digest.
+Uses full-file MD5 digests, which are stored in the directory attrib files.
+Each backup directory only contains an empty attrib file whose name includes
+its own MD5 digest, which is used to look up the attrib file's contents in the
+pool.  In turn, that file contains the metadata for every file in that
+directory, including each files's MD5 digest.
 
 =item *
 
-The Pool layout still supports chains to handle md5 collisions.  While collisions
-can be constructed and are now well-known, they are highly unlikely in the wild.
-Pool files are never renamed or moved, unlike V3.
+The Pool layout still supports chains to handle md5 collisions.  While
+collisions can be constructed and are now well-known, they are highly unlikely
+in the wild. Pool files are never renamed or moved, unlike V3.
 
 =item *
 
@@ -154,46 +147,45 @@ not filled).
 
 =item *
 
-The reverse deltas allow "infinite incrementals" - no need for a full backup
-if you are willing to trade speed for the risk that a file change will
-not be detected if the metadata (eg, mtime or size) doesn't change.
+The reverse deltas allow "infinite incrementals" - no need for a full backup if
+you are willing to trade speed for the risk that a file change will not be
+detected if the metadata (eg, mtime or size) doesn't change.
 
 =item *
 
-An rsync "full" backup now uses --checksum (instead of --ignore-times),
-which is much more efficient on the server side - the server just needs to
-check the full-file checksum computed by the client, together with the mtime,
-nlinks, size attributes, to see if the file has changed.  If you want a more
-conservative approach, you can change it back to --ignore-times, which
-requires the server to send block checksums to the client.
+An rsync "full" backup now uses --checksum (instead of --ignore-times), which
+is much more efficient on the server side - the server just needs to check the
+full-file checksum computed by the client, together with the mtime, nlinks,
+size attributes, to see if the file has changed.  If you want a more
+conservative approach, you can change it back to --ignore-times, which requires
+the server to send block checksums to the client.
 
 =item *
 
-The use of rsync --checksum allows BackupPC to guess a potential match
-anywhere in the pool, even on a first-time backup.  In that case, the usual
-rsync block checksums are still exchanged to make sure the complete file
-is identical.
+The use of rsync --checksum allows BackupPC to guess a potential match anywhere
+in the pool, even on a first-time backup.  In that case, the usual rsync block
+checksums are still exchanged to make sure the complete file is identical.
 
 =item *
 
-Uses a modified rsync called rsync_bpc (currently based on rsync-3.0.9)
-on the server side (in place of File::RsyncP), with a C code interface
-to the BackupPC storage.  So the whole data path for rsync is now in compiled
-C code, which is much faster than perl.
+Uses a modified rsync called rsync_bpc (currently based on rsync-3.0.9) on the
+server side (in place of File::RsyncP), with a C code interface to the BackupPC
+storage.  So the whole data path for rsync is now in compiled C code, which is
+much faster than perl.
 
 =item *
 
 Due to the use of rsync-3.X, acls and xattrs are supported, and many other
-useful options (but not all) are supported.  Rsync protocol 30 supports
-the efficient incremental file list, which significantly improves memory
-usage and startup time.  It also supports MD5 full-file checksums, which
-match BackupPC's new digest.  That allows a full-file digest to be checked
-as easily as an mtime on the server side.
+useful options (but not all) are supported.  Rsync protocol 30 supports the
+efficient incremental file list, which significantly improves memory usage and
+startup time.  It also supports MD5 full-file checksums, which match BackupPC's
+new digest.  That allows a full-file digest to be checked as easily as an mtime
+on the server side.
 
 =item *
 
-Significant portions of the BackupPC code are now compiled C code in a
-new module called BackupPC::XS that is dynamically linked to perl.
+Significant portions of the BackupPC code are now compiled C code in a new
+module called BackupPC::XS that is dynamically linked to perl.
 
 =back
 
@@ -203,73 +195,73 @@ Here is a more detailed discussion:
 
 =item *
 
-Completely new backup storage.  No hardlinks!  Backups are stored as reverse deltas,
-with the most recent backup always filled.  Prior backup "n" contains the changes
-relative to prior backup "n+1".
+Completely new backup storage.  No hardlinks!  Backups are stored as reverse
+deltas, with the most recent backup always filled.  Prior backup "n" contains
+the changes relative to prior backup "n+1".
 
 =item *
 
-Since every backup is based on the last filled backup, the concept of incremental
-levels is removed.
+Since every backup is based on the last filled backup, the concept of
+incremental levels is removed.
 
 =item *
 
 Example: let's assume backup #4 is the most recent, and therefore filled, and
 backups #0..3 are not filled.
 
-Backups #0..3 store just the necessary reverse changes needed to
-reconstruct those backups, relative to the next backup.
+Backups #0..3 store just the necessary reverse changes needed to reconstruct
+those backups, relative to the next backup.
 
    - To view/restore backup #4, all the information is stored in backup #4.
    - To view/restore backup #3, backup #4 (the filled one), is merged with the deltas in #3.
    - To view/restore backup #2, backup #4 (the filled one), is merged with the deltas in #3 and #2
    - etc.
 
-When a new backup is started (#5), we begin by renaming backup #4 to #5.
-At that instant, backup #4 storage is now empty (which means backups #4
-and #5 are currently identical).  As the backup runs, changes are made
-to #5 with the changed/new files in place, and the opposite changes are
-added to backup #4, to keep the "view" of backup #4 unchanged.
+When a new backup is started (#5), we begin by renaming backup #4 to #5. At
+that instant, backup #4 storage is now empty (which means backups #4 and #5 are
+currently identical).  As the backup runs, changes are made to #5 with the
+changed/new files in place, and the opposite changes are added to backup #4, to
+keep the "view" of backup #4 unchanged.
 
-After the backup is done, #5 is now the filled version of the latest
-backup, and #4 contains the changes necessary to turn #5 back into the state
-when backup #4 was done.  If there are no changes detected in the new
-backup, the storage tree for #4 will be empty.  If just one file changed,
-the new file will be below #5, and the prior file will be below #4 (well,
-technically not quite true, since files aren't stored below the backup
-trees; more correctly, the attrib file in #5 will point to the new pool
-file, and the attrib file in #4 will point to the old pool file).
+After the backup is done, #5 is now the filled version of the latest backup,
+and #4 contains the changes necessary to turn #5 back into the state when
+backup #4 was done.  If there are no changes detected in the new backup, the
+storage tree for #4 will be empty.  If just one file changed, the new file will
+be below #5, and the prior file will be below #4 (well, technically not quite
+true, since files aren't stored below the backup trees; more correctly, the
+attrib file in #5 will point to the new pool file, and the attrib file in #4
+will point to the old pool file).
 
 =item *
 
 The concepts of incr/full backups and unfilled/filled storage are now
-decoupled.  The most recent backup is always filled (whether or not the
-last backup was a full or incr).  Certain older backups can be filled
-for convenience to make restoring old backups faster (because fewer
-backups need to be merged), and are used to specify expiry schedules.
+decoupled.  The most recent backup is always filled (whether or not the last
+backup was a full or incr).  Certain older backups can be filled for
+convenience to make restoring old backups faster (because fewer backups need to
+be merged), and are used to specify expiry schedules.
 
 =item *
 
-When a backup starts, there are several different cases that determine
-how the backups are stored and whether prior deltas are stored:
+When a backup starts, there are several different cases that determine how the
+backups are stored and whether prior deltas are stored:
 
 =over 4
 
 =item 1
 
-No existing backups: create a new backup #0 and do a full backup in place
-(ie: no prior deltas are stored).
+No existing backups: create a new backup #0 and do a full backup in place (ie:
+no prior deltas are stored).
 
 =item 2
 
-V3 backups exist, but no V4 backups.  The last V3 backup is duplicated into
-V4 format, and a full backup is done in place (ie: no prior deltas are stored).
+V3 backups exist, but no V4 backups.  The last V3 backup is duplicated into V4
+format, and a full backup is done in place (ie: no prior deltas are stored).
 
 =item 3
 
 Last V4 backup is a full, or more than $Conf{FillCycle} since last filled
-backup.  The last backup is duplicated to create a new filled backup, and
-the new backup is done in place (ie: no prior deltas are stored).
+backup.  The last backup is duplicated to create a new filled backup, and the
+new backup is done in place (ie: no prior deltas are stored).
 
 =item 4
 
@@ -280,80 +272,78 @@ initially empty backup tree #n.
 =item 5
 
 CompressLevel has toggled on/off between backups.  This isn't well tested and
-it's very hard to support efficiently.  We treat this as a brand new (empty) backup
-in place, that is therefore filled.  That way we won't need to merge between
-backups with compress on/off.
+it's very hard to support efficiently.  We treat this as a brand new (empty)
+backup in place, that is therefore filled.  That way we won't need to merge
+between backups with compress on/off.
 
 =item 6
 
 Last backup was a V4 partial.  If prior V4 backup is filled (and not partial),
-then just do another in-place backup.  Otherwise, treat as case 4.  When complete
-(whether successful or another partial), delete the prior deltas in #n, which
-merges the cumulative changes into #n-1.
+then just do another in-place backup.  Otherwise, treat as case 4.  When
+complete (whether successful or another partial), delete the prior deltas in
+#n, which merges the cumulative changes into #n-1.
 
 =back
 
 =item *
 
-The treatment of a "Partial" backup has changed.  Unlike in V3 where partials are
-removed prior to the next backup, in V4 partials are kept and are used as the starting
-point for the next backup.  See case 6 above.  If the new backup fails, if no files
-have been backed up, the empty backup #n is removed.
+The treatment of a "Partial" backup has changed.  Unlike in V3 where partials
+are removed prior to the next backup, in V4 partials are kept and are used as
+the starting point for the next backup.  See case 6 above.  If the new backup
+fails, if no files have been backed up, the empty backup #n is removed.
 
 =item *
 
-Backups are stored as mangled directory trees, but each directory only
-contains an "attrib" file.  The attrib file is zero-length, and its name
-includes the MD5 digest so the contents can be looked up in the pool.
+Backups are stored as mangled directory trees, but each directory only contains
+an "attrib" file.  The attrib file is zero-length, and its name includes the
+MD5 digest so the contents can be looked up in the pool.
 
-The attrib contents in the pool contains the directory contents: for each
-file, that means the metadata, xattrs and the MD5 digest of the file
-contents.
-
-=item *
-
-A modified rsync called rsync_bpc, based on rsync 3.0.9, is used on
-the server side, with a C code layer that emulates all the file-system
-OS calls to be compatible with the BackupPC store.  That means for
-rsync, the data path is now fully in compiled C, which should mean a
-significant speedup.  It also means many (but not all) of the rsync
-options are supported natively.
+The attrib contents in the pool contains the directory contents: for each file,
+that means the metadata, xattrs and the MD5 digest of the file contents.
 
 =item *
 
-Significant parts of the BackupPC storage and pooling code have been written in C
-(the same code is used in the server rsync_bpc).  BackupPC::FileZIO, BackupPC::PoolWrite,
-BackupPC::Attrib, BackupPC::AttribCache and BackupPC::PoolRefCnt (reference counting and
-storage) are all replaced with BackupPC::XS, a C-code perl extension.
+A modified rsync called rsync_bpc, based on rsync 3.0.9, is used on the server
+side, with a C code layer that emulates all the file-system OS calls to be
+compatible with the BackupPC store.  That means for rsync, the data path is now
+fully in compiled C, which should mean a significant speedup.  It also means
+many (but not all) of the rsync options are supported natively.
 
 =item *
 
-Extended attributes (xattr) are supported.  Rsync is configured to "store acls using xattr",
-meaning both acls and xattrs are supported.
+Significant parts of the BackupPC storage and pooling code have been written in
+C (the same code is used in the server rsync_bpc).  BackupPC::FileZIO,
+BackupPC::PoolWrite, BackupPC::Attrib, BackupPC::AttribCache and
+BackupPC::PoolRefCnt (reference counting and storage) are all replaced with
+BackupPC::XS, a C-code perl extension.
 
 =item *
 
-infinite incrementals with rsync are supported.  The most recent backup
-is always filled, so an incremental will still leave the most recent
-backup filled.
+Extended attributes (xattr) are supported.  Rsync is configured to "store acls
+using xattr", meaning both acls and xattrs are supported.
 
 =item *
 
-any V4 backup can be deleted - dependencies are merged into the next older backup
-if it isn't already filled.
+infinite incrementals with rsync are supported.  The most recent backup is
+always filled, so an incremental will still leave the most recent backup
+filled.
 
 =item *
 
-file digests are full-file MD5.  Collisions are much more unlikely than V3,
-but still possible.  Duplicates are implemented with an extension to the
-16 byte MD5 digest (ie: 16 bytes for plain file, 17 bytes for next
-255 duplicates etc).
+any V4 backup can be deleted - dependencies are merged into the next older
+backup if it isn't already filled.
 
 =item *
 
-V4 pool files are stored in a new hierarchy, two levels deep, with
-7 bits at each level (ie: 128 directories at top-level, and each
-with 128 directories at next level).
+file digests are full-file MD5.  Collisions are much more unlikely than V3, but
+still possible.  Duplicates are implemented with an extension to the 16 byte
+MD5 digest (ie: 16 bytes for plain file, 17 bytes for next 255 duplicates etc).
+
+=item *
+
+V4 pool files are stored in a new hierarchy, two levels deep, with 7 bits at
+each level (ie: 128 directories at top-level, and each with 128 directories at
+next level).
 
 =item *
 
@@ -361,9 +351,9 @@ V4 pool files are never moved or renamed.
 
 =item *
 
-Inodes for hardlinked files are stored in each backup tree.  This makes
-backing up hardlinks accurate, compared to V3, and provides for consistent
-inode numbering across backups.
+Inodes for hardlinked files are stored in each backup tree.  This makes backing
+up hardlinks accurate, compared to V3, and provides for consistent inode
+numbering across backups.
 
 =item *
 
@@ -371,8 +361,8 @@ zero-sized files or empty attribute files don't get written or pooled.
 
 =item *
 
-the elimination of hardlinks means that reference counting has to be maintained by
-the BackupPC code.  This is one of the riskiest area in terms of development
+the elimination of hardlinks means that reference counting has to be maintained
+by the BackupPC code.  This is one of the riskiest area in terms of development
 and testing.  Reference counts are maintained per-backup, per-host, and for the
 whole pool.
 
@@ -382,44 +372,42 @@ files in that client's backup directory (ie: TopDir/pc/HOST/NNN).  These files
 are lists of MD5 digests, and corresponding counts deltas.
 
 Each night, BackupPC_nightly runs BackupPC_refCountUpdate, which, for each
-host, updates the per-host reference count database with the new deltas.
-It then combines all the per-host reference count files to create the
-global pool reference count database.
+host, updates the per-host reference count database with the new deltas. It
+then combines all the per-host reference count files to create the global pool
+reference count database.
 
-BackupPC_refCountUpdate can run concurrently with backups.  If you still
-have V3 backups and pool, BackupPC_nightly still needs to run and check
-for old V3 pool files that can be deleted.  But since there are no
-new V3 backups happening, BackupPC_nightly can run concurrently with
-backups.
+BackupPC_refCountUpdate can run concurrently with backups.  If you still have
+V3 backups and pool, BackupPC_nightly still needs to run and check for old V3
+pool files that can be deleted.  But since there are no new V3 backups
+happening, BackupPC_nightly can run concurrently with backups.
 
 =item *
 
-There is a new utility BackupPC_fsck that can check/fix the per-host
-and global reference counts.  The per-host reference count database
-is verified by parsing all the attrib files in each backup tree.
-The global reference count database is verified by combing all the
-per-host reference count databases and comparing them.
+There is a new utility BackupPC_fsck that can check/fix the per-host and global
+reference counts.  The per-host reference count database is verified by parsing
+all the attrib files in each backup tree. The global reference count database
+is verified by combing all the per-host reference count databases and comparing
+them.
 
 BackupPC_fsck cannot run when BackupPC is.
 
 =item *
 
-When BackupPC_refCountUpdate updates the overall reference counts, it
-removes pool files that have a reference count of zero.  To avoid race
-conditions, it uses a two-phase process.  It first flags files that have
-zero reference counts using one of the file attributes.  The next time
-it runs (typically 24 hours later), any flagged files that still have
-zero reference count are then removed.  The rest of the code knows not
-to use flagged pool files to avoid race conditions.
+When BackupPC_refCountUpdate updates the overall reference counts, it removes
+pool files that have a reference count of zero.  To avoid race conditions, it
+uses a two-phase process.  It first flags files that have zero reference counts
+using one of the file attributes.  The next time it runs (typically 24 hours
+later), any flagged files that still have zero reference count are then
+removed.  The rest of the code knows not to use flagged pool files to avoid
+race conditions.
 
 =item *
 
-Progress indication: a simple status that shows the number of files
-processed so far.  It's hard to convert that to a percentage, since
-the total isn't known until the end of the backup.  But knowing the
-number of files is quite helpful, since you can get an idea of the
-expected total based on the prior backups, or knowing what configuration
-you have changed (ie: adding a large new tree).
+Progress indication: a simple status that shows the number of files processed
+so far.  It's hard to convert that to a percentage, since the total isn't known
+until the end of the backup.  But knowing the number of files is quite helpful,
+since you can get an idea of the expected total based on the prior backups, or
+knowing what configuration you have changed (ie: adding a large new tree).
 
 =item *
 
@@ -427,84 +415,80 @@ BackupPC_link is removed since it is no longer used.
 
 =item *
 
-Since files are no longer stored in backup trees, browsing the backup
-trees is even harder than V3 (where you just had to deal with mangling).
-A new utility BackupPC_ls acts like "ls -l", showing accurate directory
-listings of files, together with the MD5 digests.
+Since files are no longer stored in backup trees, browsing the backup trees is
+even harder than V3 (where you just had to deal with mangling). A new utility
+BackupPC_ls acts like "ls -l", showing accurate directory listings of files,
+together with the MD5 digests.
 
-BackupPC_ls can be given either an explicit hostname, number,
-and unmangled path, or can be given the full (mangled) path,
-which makes it easier to use directory completion.  It should
-be possible to configure tcsh and bash, together with some new
-hooks in BackupPC_ls, to give a more natural file/directory
-completion.
+BackupPC_ls can be given either an explicit hostname, number, and unmangled
+path, or can be given the full (mangled) path, which makes it easier to use
+directory completion.  It should be possible to configure tcsh and bash,
+together with some new hooks in BackupPC_ls, to give a more natural
+file/directory completion.
 
-BackupPC_zcat also can take just the MD5 digest (which you can paste
-from BackupPC_ls).  Currently BackupPC_zcat doesn't support the tree
-parsing that BackupPC_ls does (it can only zcat actual files),  but
-that should be easy to rectify.
+BackupPC_zcat also can take just the MD5 digest (which you can paste from
+BackupPC_ls).  Currently BackupPC_zcat doesn't support the tree parsing that
+BackupPC_ls does (it can only zcat actual files),  but that should be easy to
+rectify.
 
 =item *
 
 Configuration for expiry: since full/incr are decoupled from filled/unfilled,
 expiry is a bit trickier.
 
-The convention for expiry parameters is "FullKeepPeriod/FullKeepCnt"
-etc refer to B<Filled> backups, and "IncrKeepPeriod/IncrKeepCnt" refer
-to B<Unfilled> backups.
+The convention for expiry parameters is "FullKeepPeriod/FullKeepCnt" etc refer
+to B<Filled> backups, and "IncrKeepPeriod/IncrKeepCnt" refer to B<Unfilled>
+backups.
 
 =item *
 
-V3 migration: nothing specific is needed.  V4 can browse/view/restore
-V3 backups.  When you install V4, no changes are made to any V3 backups.
-If you are upgrading from V3, be sure to set $Conf{PoolV3Enabled} to 1 so
-the old V3 pool is searched for matching files.
+V3 migration: nothing specific is needed.  V4 can browse/view/restore V3
+backups.  When you install V4, no changes are made to any V3 backups. If you
+are upgrading from V3, be sure to set $Conf{PoolV3Enabled} to 1 so the old V3
+pool is searched for matching files.
 
 =over 4
 
 =item *
 
 When you install V4, it will notice that the V3 pool exists.  Running
-configure.pl should set $Conf{PoolV3Enabled} to 1 in that case, but
-you should be sure to check that.
+configure.pl should set $Conf{PoolV3Enabled} to 1 in that case, but you should
+be sure to check that.
 
 =item *
 
-When a V4 backup is first done, BackupPC_backupDuplicate is
-run to duplicate the most recent V3 backup to create a new V4 backup.
-A "filled" view of the most recent V3 backup is used to create
-a "filled" V4 backup tree.
+When a V4 backup is first done, BackupPC_backupDuplicate is run to duplicate
+the most recent V3 backup to create a new V4 backup. A "filled" view of the
+most recent V3 backup is used to create a "filled" V4 backup tree.
 
-This step could be time consuming, since every file needs to be read
-(as a V3 file) and written as a V4 file.  However, the V4 pooling
-code knows about the V3 pool, so it will move the V3 pool file
-into the V4 pool.  So this duplication process doesn't burn a lot of
-pool storage space, but every file still needs to be read
-(to compute the MD5 digest) and "written" (really just
+This step could be time consuming, since every file needs to be read (as a V3
+file) and written as a V4 file.  However, the V4 pooling code knows about the
+V3 pool, so it will move the V3 pool file into the V4 pool.  So this
+duplication process doesn't burn a lot of pool storage space, but every file
+still needs to be read (to compute the MD5 digest) and "written" (really just
 matching/linking).
 
 =item *
 
-Expiry: all the V3 + V4 backups are considered on a combined basis
-for expiry checking.
+Expiry: all the V3 + V4 backups are considered on a combined basis for expiry
+checking.
 
 =item *
 
-On a clean new V4 install, the steps of computing and checking V3
-digests is eliminated.
+On a clean new V4 install, the steps of computing and checking V3 digests is
+eliminated.
 
 =item *
 
-Downgrading V4->V3: Not tested and not recommended.
-In theory you can remove any new V4 backups, remove the V4 pool
-itself, and you should be able to re-install V3 and still have
-access to your original full working V3 store (except for any
-V3 backups that V4 might have routinely removed based on normal
+Downgrading V4->V3: Not tested and not recommended. In theory you can remove
+any new V4 backups, remove the V4 pool itself, and you should be able to
+re-install V3 and still have access to your original full working V3 store
+(except for any V3 backups that V4 might have routinely removed based on normal
 backup expiry configuration).
 
-However, any V3 pool files moved to V4 will no longer be in the V3
-pool.  So subsequent V3 backups will burn more storage as files
-get re-added to the old V3 pool.
+However, any V3 pool files moved to V4 will no longer be in the V3 pool.  So
+subsequent V3 backups will burn more storage as files get re-added to the old
+V3 pool.
 
 Hopefully downgrading isn't necessary...
 
@@ -526,9 +510,9 @@ rsync-bpc doesn't support checksum caching.
 =item *
 
 rsync-bpc with --ignore-times actually reads each unchanged file three times,
-and writes it once (normal rsync reads twice and writes once; the extra one
-is due to compression).  Some careful optimization can eliminate two reads
-and the write.  The final read can be eliminated with checksum caching.
+and writes it once (normal rsync reads twice and writes once; the extra one is
+due to compression).  Some careful optimization can eliminate two reads and the
+write.  The final read can be eliminated with checksum caching.
 
 =item *
 
@@ -545,98 +529,90 @@ BackupPC_backupDelete are all single-threaded.
 
 =item Full Backup
 
-A full backup is a complete backup of a share. BackupPC can be configured
-to do a full backup at a regular interval (typically weekly).  BackupPC
-can be configured to keep a certain number of full backups.  Exponential
-expiry is also supported, allowing full backups with various vintages to
-be kept (for example, a settable number of most recent weekly fulls, plus
-a settable number of older fulls that are 2, 4, 8, or 16 weeks apart).
+A full backup is a complete backup of a share. BackupPC can be configured to do
+a full backup at a regular interval (typically weekly).  BackupPC can be
+configured to keep a certain number of full backups.  Exponential expiry is
+also supported, allowing full backups with various vintages to be kept (for
+example, a settable number of most recent weekly fulls, plus a settable number
+of older fulls that are 2, 4, 8, or 16 weeks apart).
 
 =item Incremental Backup
 
-An incremental backup is a backup of files that have changed since the
-last successful backup.
+An incremental backup is a backup of files that have changed since the last
+successful backup.
 
-Rsync is the best option for BackupPC.  Any files whose attributes
-have changed (ie: uid, gid, mtime, modes, size) since the last full
-are backed up.  Deleted, new files and renamed files are detected by
-rsync incrementals.
+Rsync is the best option for BackupPC.  Any files whose attributes have changed
+(ie: uid, gid, mtime, modes, size) since the last full are backed up.  Deleted,
+new files and renamed files are detected by rsync incrementals.
 
-For SMB and tar, BackupPC uses the modification time (mtime) to
-determine which files have changed since the last backup.  That
-means SMB and tar incrementals are not able to detect deleted files,
-renamed files or new files whose modification time is prior to the
-last lower-level backup.
+For SMB and tar, BackupPC uses the modification time (mtime) to determine which
+files have changed since the last backup.  That means SMB and tar incrementals
+are not able to detect deleted files, renamed files or new files whose
+modification time is prior to the last lower-level backup.
 
 BackupPC can also be configured to keep a certain number of incremental
 backups, and to keep a smaller number of very old incremental backups.
 
-BackupPC "fills-in" incremental backups when browsing or restoring,
-based on the levels of each backup, giving every backup a "full"
-appearance.  This makes browsing and restoring backups much easier:
-you can restore from any one backup independent of whether it was
-an incremental or full.
+BackupPC "fills-in" incremental backups when browsing or restoring, based on
+the levels of each backup, giving every backup a "full" appearance.  This makes
+browsing and restoring backups much easier: you can restore from any one backup
+independent of whether it was an incremental or full.
 
 =item Partial Backup
 
-When a full or incremental backup fails or is canceled, the most
-recent backup is labeled "partial".  Prior to V4, that backup was
-incomplete, and would be deleted when the next backup completed.
+When a full or incremental backup fails or is canceled, the most recent backup
+is labeled "partial".  Prior to V4, that backup was incomplete, and would be
+deleted when the next backup completed.
 
-In V4 a partial backup denotes that the last backup is incomplete.
-However, since V4 does backup updating in place, it represents the best
-and latest backup.  A partial backup can be browsed or used to restore
-files just like a successful full or incremental backup.  And it will
-be used as the starting point for the next backup attempt.
+In V4 a partial backup denotes that the last backup is incomplete. However,
+since V4 does backup updating in place, it represents the best and latest
+backup.  A partial backup can be browsed or used to restore files just like a
+successful full or incremental backup.  And it will be used as the starting
+point for the next backup attempt.
 
 =item Identical Files
 
-BackupPC pools identical files.  By "identical files" we mean files
-with identical contents, not necessary the same permissions, ownership
-or modification time.  Two files might have different permissions,
-ownership, or modification time but will still be pooled whenever
-the contents are identical.  This is possible since BackupPC stores
-the file metadata (permissions, ownership, and modification time)
-separately from the file contents.
+BackupPC pools identical files.  By "identical files" we mean files with
+identical contents, not necessary the same permissions, ownership or
+modification time.  Two files might have different permissions, ownership, or
+modification time but will still be pooled whenever the contents are identical.
+ This is possible since BackupPC stores the file metadata (permissions,
+ownership, and modification time) separately from the file contents.
 
-Prior to V4, identical files were stored using hardlinks.  In V4+,
-hardlinks are eliminated (except for temporary atomic renames), and
-reference counting is done at the application level.
+Prior to V4, identical files were stored using hardlinks.  In V4+, hardlinks
+are eliminated (except for temporary atomic renames), and reference counting is
+done at the application level.
 
 =item Backup Policy
 
-Based on your site's requirements you need to decide what your backup
-policy is.  BackupPC is not designed to provide exact re-imaging of
-failed disks.  See L<Some Limitations> for more information.
-However, with rsync and tar transports for linux/unix clients, plus
-full support for special file types, extended attributes etc,
-likely means an exact image of a linux/unix file system can be made.
+Based on your site's requirements you need to decide what your backup policy
+is.  BackupPC is not designed to provide exact re-imaging of failed disks.  See
+L<Some Limitations> for more information. However, with rsync and tar
+transports for linux/unix clients, plus full support for special file types,
+extended attributes etc, likely means an exact image of a linux/unix file
+system can be made.
 
 BackupPC saves backups onto disk. Because of pooling you can relatively
 economically keep several weeks or months of old backups.
 
-At some sites the disk-based backup will be adequate, without a
-secondary offsite cloud, disk or tape backup. This system is robust
-to any single failure: if a client disk fails or loses files, the
-BackupPC server can be used to restore files. If the server disk
-fails, BackupPC can be restarted on a fresh file system, and create
-new backups from the clients. The chance of the server disk failing
-can be made very small by spending more money on increasingly better
-RAID systems.  However, there is still the risk of catastrophic
-events like fires or earthquakes that can destroy both the BackupPC
-server and the clients it is backing up if they are physically
-nearby.
+At some sites the disk-based backup will be adequate, without a secondary
+offsite cloud, disk or tape backup. This system is robust to any single
+failure: if a client disk fails or loses files, the BackupPC server can be used
+to restore files. If the server disk fails, BackupPC can be restarted on a
+fresh file system, and create new backups from the clients. The chance of the
+server disk failing can be made very small by spending more money on
+increasingly better RAID systems.  However, there is still the risk of
+catastrophic events like fires or earthquakes that can destroy both the
+BackupPC server and the clients it is backing up if they are physically nearby.
 
-Some sites might choose to do periodic backups to tape or cd/dvd.
-This backup can be done perhaps weekly using the archive function of
-BackupPC.
+Some sites might choose to do periodic backups to tape or cd/dvd. This backup
+can be done perhaps weekly using the archive function of BackupPC.
 
-Other users have reported success with removable disks to rotate the
-BackupPC data drives, or using rsync to mirror the BackupPC data pool
-offsite.
+Other users have reported success with removable disks to rotate the BackupPC
+data drives, or using rsync to mirror the BackupPC data pool offsite.
 
-In V4, since hardlinks are not used permanently, duplicating a V4 pool
-is much easier, allowing remote copying of the pool.
+In V4, since hardlinks are not used permanently, duplicating a V4 pool is much
+easier, allowing remote copying of the pool.
 
 =back
 
@@ -650,8 +626,8 @@ The BackupPC project page is at:
 
     https://backuppc.github.io/backuppc
 
-This page has links to the current documentation, github project source
-and general information.
+This page has links to the current documentation, github project source and
+general information.
 
 =item Github
 
@@ -668,9 +644,9 @@ available at:
 
 =item BackupPC Wiki
 
-BackupPC has a Wiki at L<https://github.com/backuppc/backuppc/wiki>.
-Everyone is encouraged to contribute to the Wiki.  Anyone with a
-Github account can edit the Wiki.
+BackupPC has a Wiki at L<https://github.com/backuppc/backuppc/wiki>. Everyone
+is encouraged to contribute to the Wiki.  Anyone with a Github account can edit
+the Wiki.
 
 =item Mailing lists
 
@@ -688,14 +664,13 @@ You can subscribe to these lists by visiting:
     http://lists.sourceforge.net/lists/listinfo/backuppc-users
     http://lists.sourceforge.net/lists/listinfo/backuppc-devel
 
-The backuppc-announce list is moderated and is used only for
-important announcements (eg: new versions).  It is low traffic.
-You only need to subscribe to one of backuppc-announce and
-backuppc-users: backuppc-users also receives any messages on
-backuppc-announce.
+The backuppc-announce list is moderated and is used only for important
+announcements (eg: new versions).  It is low traffic. You only need to
+subscribe to one of backuppc-announce and backuppc-users: backuppc-users also
+receives any messages on backuppc-announce.
 
-The backuppc-devel list is only for developers who are working on BackupPC.
-Do not post questions or support requests there.  But detailed technical
+The backuppc-devel list is only for developers who are working on BackupPC. Do
+not post questions or support requests there.  But detailed technical
 discussions should happen on this list.
 
 To post a message to the backuppc-users list, send an email to
@@ -706,25 +681,24 @@ Do not send subscription requests to this address!
 
 =item Other Programs of Interest
 
-If you want to mirror linux or unix files or directories to a remote server
-you should use rsync, L<http://rsync.samba.org>.  BackupPC uses
-rsync as a transport mechanism; if you are already an rsync user you
-can think of BackupPC as adding efficient storage (compression and
-pooling) and a convenient user interface to rsync.
+If you want to mirror linux or unix files or directories to a remote server you
+should use rsync, L<http://rsync.samba.org>.  BackupPC uses rsync as a
+transport mechanism; if you are already an rsync user you can think of BackupPC
+as adding efficient storage (compression and pooling) and a convenient user
+interface to rsync.
 
-Two popular open source packages that do tape backup are
-Amanda (L<http://www.amanda.org>)
-and Bacula (L<http://www.bacula.org>).
-These packages can be used as complete solutions, or also as back
-ends to BackupPC to backup the BackupPC server data to tape.
+Two popular open source packages that do tape backup are Amanda
+(L<http://www.amanda.org>) and Bacula (L<http://www.bacula.org>). These
+packages can be used as complete solutions, or also as back ends to BackupPC to
+backup the BackupPC server data to tape.
 
-Avery Pennarun's bup (L<https://github.com/bup/bup>) uses the git packfile format to
-do efficient incrementals and deduplication.
-Various programs and scripts use rsync to provide hardlinked backups.
-See, for example, Mike Rubel's site (L<http://www.mikerubel.org/computers/rsync_snapshots>),
-JW Schultz's dirvish (L<http://www.dirvish.org/>),
-Ben Escoto's rdiff-backup (L<http://www.nongnu.org/rdiff-backup>),
-and John Bowman's rlbackup (L<http://www.math.ualberta.ca/imaging/rlbackup>).
+Avery Pennarun's bup (L<https://github.com/bup/bup>) uses the git packfile
+format to do efficient incrementals and deduplication. Various programs and
+scripts use rsync to provide hardlinked backups. See, for example, Mike Rubel's
+site (L<http://www.mikerubel.org/computers/rsync_snapshots>), JW Schultz's
+dirvish (L<http://www.dirvish.org/>), Ben Escoto's rdiff-backup
+(L<http://www.nongnu.org/rdiff-backup>), and John Bowman's rlbackup
+(L<http://www.math.ualberta.ca/imaging/rlbackup>).
 
 BackupPC provides many additional features, such as compressed storage,
 deduplicating any matching files (rather than just files with the same name),
@@ -736,25 +710,25 @@ consideration.
 
 =head2 Road map
 
-The new features planned for future releases of BackupPC
-are on the Wiki at L<https://github.com/backuppc/backuppc/wiki>.
+The new features planned for future releases of BackupPC are on the Wiki at
+L<https://github.com/backuppc/backuppc/wiki>.
 
 Comments and suggestions are welcome.
 
 =head2 You can help
 
-BackupPC is free. I work on BackupPC because I enjoy doing it and I like
-to contribute to the open source community.
+BackupPC is free. I work on BackupPC because I enjoy doing it and I like to
+contribute to the open source community.
 
-BackupPC already has more than enough features for my own needs.  The
-main compensation for continuing to work on BackupPC is knowing that
-more and more people find it useful.  So feedback is certainly
-appreciated, both positive and negative.
+BackupPC already has more than enough features for my own needs.  The main
+compensation for continuing to work on BackupPC is knowing that more and more
+people find it useful.  So feedback is certainly appreciated, both positive and
+negative.
 
-Also, everyone is encouraged to contribute patches, bug reports,
-feature and design suggestions, new code, Wiki additions (you can
-do those directly) and documentation corrections or improvements.
-Answering questions on the mailing list is a big help too.
+Also, everyone is encouraged to contribute patches, bug reports, feature and
+design suggestions, new code, Wiki additions (you can do those directly) and
+documentation corrections or improvements. Answering questions on the mailing
+list is a big help too.
 
 =head1 Installing BackupPC
 
@@ -766,179 +740,171 @@ BackupPC requires:
 
 =item *
 
-A linux, solaris, or unix based server with a substantial amount of free
-disk space (see the next section for what that means). The CPU and disk
-performance on this server will determine how many simultaneous backups
-you can run. You should be able to run 4-8 simultaneous backups on a
-moderately configured server.
+A linux, solaris, or unix based server with a substantial amount of free disk
+space (see the next section for what that means). The CPU and disk performance
+on this server will determine how many simultaneous backups you can run. You
+should be able to run 4-8 simultaneous backups on a moderately configured
+server.
 
-It is also recommended you consider either an LVM or RAID setup so that
-you can expand the file system as necessary.
-
-=item *
-
-Perl version 5.8.0 or later.  If you don't have perl, please
-see L<http://www.cpan.org>.
+It is also recommended you consider either an LVM or RAID setup so that you can
+expand the file system as necessary.
 
 =item *
 
-The perl modules BackupPC::XS (version >= 0.50) is required, and
-several others, File::Listing, Archive::Zip, XML::RSS, JSON::XS, Net::FTP,
+Perl version 5.8.0 or later.  If you don't have perl, please see
+L<http://www.cpan.org>.
+
+=item *
+
+The perl modules BackupPC::XS (version >= 0.50) is required, and several
+others, File::Listing, Archive::Zip, XML::RSS, JSON::XS, Net::FTP,
 Net::FTP::RetrHandle, Net::FTP::AutoReconnect are recommended.
 
 Try "perldoc BackupPC::XS" and "perldoc Archive::Zip" to see if you have these
 modules.  If not, fetch them from L<http://www.cpan.org> and see the
 instructions below for how to build and install them.
 
-The CGI Perl module is required for the http/cgi user interface. CGI was a core module,
-but from version 5.22 Perl no longer ships with it.
+The CGI Perl module is required for the http/cgi user interface. CGI was a core
+module, but from version 5.22 Perl no longer ships with it.
 
 =item *
 
-If you are using rsync to backup linux/unix machines you should have
-rsync on each client machine.  Version 3+ is strongly recommended, but
-earlier versions will work too. See L<http://rsync.samba.org>.
-Use "rsync --version" to check your version.
+If you are using rsync to backup linux/unix machines you should have rsync on
+each client machine.  Version 3+ is strongly recommended, but earlier versions
+will work too. See L<http://rsync.samba.org>. Use "rsync --version" to check
+your version.
 
-For BackupPC to use Rsync you will also need to install rsync-bpc on
-the server.
+For BackupPC to use Rsync you will also need to install rsync-bpc on the
+server.
 
 =item *
 
-If you are using smb to backup WinXX machines you need smbclient and
-nmblookup from the samba package.  You will also need nmblookup if
-you are backing up linux/unix DHCP machines.  See L<http://www.samba.org>.
+If you are using smb to backup WinXX machines you need smbclient and nmblookup
+from the samba package.  You will also need nmblookup if you are backing up
+linux/unix DHCP machines.  See L<http://www.samba.org>.
 
-See L<http://www.samba.org> for source and binaries.  It's pretty easy to
-fetch and compile samba, and just grab smbclient and nmblookup, without
-doing the installation. Alternatively, L<http://www.samba.org> has binary
-distributions for most platforms.
+See L<http://www.samba.org> for source and binaries.  It's pretty easy to fetch
+and compile samba, and just grab smbclient and nmblookup, without doing the
+installation. Alternatively, L<http://www.samba.org> has binary distributions
+for most platforms.
 
 =item *
 
 If you are using tar to backup linux/unix machines, those machines should have
-version 1.13.20 or higher recommended.  Use "tar --version" to check your version.
-Various GNU mirrors have the newest versions of tar;
-see L<http://www.gnu.org/software/tar/>.
+version 1.13.20 or higher recommended.  Use "tar --version" to check your
+version. Various GNU mirrors have the newest versions of tar; see
+L<http://www.gnu.org/software/tar/>.
 
 =item *
 
-The Apache web server, see L<http://www.apache.org>, preferably built
-with mod_perl support.
+The Apache web server, see L<http://www.apache.org>, preferably built with
+mod_perl support.
 
 =item *
 
-If rrdtool is installed on the BackupPC server, graphs of the pool usage
-will be maintained and displayed.  To enable the graphs, point $Conf{RrdToolPath}
-to the rrdtool executable.
+If rrdtool is installed on the BackupPC server, graphs of the pool usage will
+be maintained and displayed.  To enable the graphs, point $Conf{RrdToolPath} to
+the rrdtool executable.
 
 =back
 
 =head2 What type of storage space do I need?
 
 Starting with 4.0.0, BackupPC no longer uses hardlinks for storage of
-deduplicated files.  However, hardlinks are still used temporarily in
-a few places for doing atomic renames, with a fallback doing a file copy
-if the hardlink fails, and files are moved (renamed) across various paths
-that turn into expensive file copies if they span multiple file systems.
+deduplicated files.  However, hardlinks are still used temporarily in a few
+places for doing atomic renames, with a fallback doing a file copy if the
+hardlink fails, and files are moved (renamed) across various paths that turn
+into expensive file copies if they span multiple file systems.
 
 So ideally BackupPC's data store (__TOPDIR__) is a single file system that
 supports hardlinks.  It is ok to use a single symbolic link at the top-level
-directory (__TOPDIR__) to point the entire data store somewhere else).
-You can of course use any kind of RAID system or logical volume manager
-that combines the capacity of multiple disks into a single, larger,
-file system. Such approaches have the advantage that the file system can
-be expanded without having to copy it.
+directory (__TOPDIR__) to point the entire data store somewhere else). You can
+of course use any kind of RAID system or logical volume manager that combines
+the capacity of multiple disks into a single, larger, file system. Such
+approaches have the advantage that the file system can be expanded without
+having to copy it.
 
-Any standard linux or unix file system supports hardlinks.  NFS mounted
-file systems work too (provided the underlying file system supports
-hardlinks).  But windows based FAT and NTFS file systems will not work.
+Any standard linux or unix file system supports hardlinks.  NFS mounted file
+systems work too (provided the underlying file system supports hardlinks).  But
+windows based FAT and NTFS file systems will not work.
 
-In BackupPC 3.x, hardlinks are fundamental to deduplication, so a startup
-check is done ensure that the file system can support hardlinks, since
-this is a common area of configuration problems in v3.  In 4.x, that check
-is only done if the pool still contains v3 backups and pool files.
+In BackupPC 3.x, hardlinks are fundamental to deduplication, so a startup check
+is done ensure that the file system can support hardlinks, since this is a
+common area of configuration problems in v3.  In 4.x, that check is only done
+if the pool still contains v3 backups and pool files.
 
 =head2 How much disk space do I need?
 
-Here's one real example (circa 2002) for an environment that is
-backing up 65 laptops with compression off. Each full backup averages
-3.2GB. Each incremental backup averages about 0.2GB. Storing one
-full backup and two incremental backups per laptop is around 240GB
-of raw data. But because of the pooling of identical files, only
-87GB is used.  This is without compression.
+Here's one real example (circa 2002) for an environment that is backing up 65
+laptops with compression off. Each full backup averages 3.2GB. Each incremental
+backup averages about 0.2GB. Storing one full backup and two incremental
+backups per laptop is around 240GB of raw data. But because of the pooling of
+identical files, only 87GB is used.  This is without compression.
 
-Another example, with compression on: backing up 95 laptops, where
-each backup averages 3.6GB and each incremental averages about 0.3GB.
-Keeping three weekly full backups, and six incrementals is around
-1200GB of raw data.  Because of pooling and compression, only 150GB
-is needed.
+Another example, with compression on: backing up 95 laptops, where each backup
+averages 3.6GB and each incremental averages about 0.3GB. Keeping three weekly
+full backups, and six incrementals is around 1200GB of raw data.  Because of
+pooling and compression, only 150GB is needed.
 
-Here's a rule of thumb. Add up the disk usage of all the machines you
-want to backup (210GB in the first example above). This is a rough
-minimum space estimate that should allow a couple of full backups and at
-least half a dozen incremental backups per machine. If compression is on
-you can reduce the storage requirements by maybe 30-40%.  Add some margin
-in case you add more machines or decide to keep more old backups.
+Here's a rule of thumb. Add up the disk usage of all the machines you want to
+backup (210GB in the first example above). This is a rough minimum space
+estimate that should allow a couple of full backups and at least half a dozen
+incremental backups per machine. If compression is on you can reduce the
+storage requirements by maybe 30-40%.  Add some margin in case you add more
+machines or decide to keep more old backups.
 
-Your actual mileage will depend upon the types of clients, operating
-systems and applications you have. The more uniform the clients and
-applications the bigger the benefit from pooling common files.
+Your actual mileage will depend upon the types of clients, operating systems
+and applications you have. The more uniform the clients and applications the
+bigger the benefit from pooling common files.
 
-In addition to total disk space, you should make sure you have
-plenty of inodes on your BackupPC data partition. Some users have
-reported running out of inodes on their BackupPC data partition.
-So even if you have plenty of disk space, BackupPC will report
-failures when the inodes are exhausted.  This is a particular
-problem with ext2/ext3 file systems that have a fixed number of
-inodes when the file system is built.  Use "df -i" to see your
-inode usage.
+In addition to total disk space, you should make sure you have plenty of inodes
+on your BackupPC data partition. Some users have reported running out of inodes
+on their BackupPC data partition. So even if you have plenty of disk space,
+BackupPC will report failures when the inodes are exhausted.  This is a
+particular problem with ext2/ext3 file systems that have a fixed number of
+inodes when the file system is built.  Use "df -i" to see your inode usage.
 
 =head2 Step 1: Getting BackupPC
 
-Many linux distributions now include BackupPC, so installing
-BackupPC via your package manager is the best approach.
+Many linux distributions now include BackupPC, so installing BackupPC via your
+package manager is the best approach.
 
 For example, for Debian, supported by Ludovic Drolez, can be found at
-L<http://packages.debian.org/backuppc> and is included in the current
-stable Debian release.  On Debian, BackupPC can be installed with
-the command:
+L<http://packages.debian.org/backuppc> and is included in the current stable
+Debian release.  On Debian, BackupPC can be installed with the command:
 
     apt-get install backuppc
 
-You should also install rsync-bpc; the BackupPC package might include
-it already, but if not:
+You should also install rsync-bpc; the BackupPC package might include it
+already, but if not:
 
     apt-get install rsync-bpc
 
 If those commands work, you can skip to Step 3.
 
-Alternatively, manually fetching and installing BackupPC is easy.
-Start by downloading the latest version from
+Alternatively, manually fetching and installing BackupPC is easy. Start by
+downloading the latest version from
 
     https://github.com/backuppc/backuppc/releases
 
 =head2 Step 2: Installing the distribution
 
-Note: most information in this step is only relevant if you build
-and install BackupPC yourself.  If you use a package provided by a
-distribution, the package management system should take of installing
-any needed dependencies.
+Note: most information in this step is only relevant if you build and install
+BackupPC yourself.  If you use a package provided by a distribution, the
+package management system should take of installing any needed dependencies.
 
-First off, there are several perl modules you should install.  The
-first one, BackupPC::XS, is required.  The others are optional
-but highly recommended.  Use either your linux package manager,
-or the cpan command, or follow the instructions in the README files
-to install these packages:
+First off, there are several perl modules you should install.  The first one,
+BackupPC::XS, is required.  The others are optional but highly recommended. Use
+either your linux package manager, or the cpan command, or follow the
+instructions in the README files to install these packages:
 
 =over 4
 
 =item BackupPC::XS
 
-Significant portions of BackupPC are implemented in C code contained in
-this module.  You can run "perldoc BackupPC::XS" to see if this module
-is installed.  You need to have version >= 0.50.  BackupPC::XS is
-available from:
+Significant portions of BackupPC are implemented in C code contained in this
+module.  You can run "perldoc BackupPC::XS" to see if this module is installed.
+ You need to have version >= 0.50.  BackupPC::XS is available from:
 
     https://github.com/backuppc/backuppc-xs/releases
 
@@ -946,46 +912,47 @@ and also CPAN.
 
 =item Archive::Zip
 
-To support restore via Zip archives you will need to install
-Archive::Zip, also from L<http://www.cpan.org>.
-You can run "perldoc Archive::Zip" to see if this module is installed.
+To support restore via Zip archives you will need to install Archive::Zip, also
+from L<http://www.cpan.org>. You can run "perldoc Archive::Zip" to see if this
+module is installed.
 
 =item XML::RSS
 
 To support the RSS feature you will need to install XML::RSS, also from
-L<http://www.cpan.org>. There is not need to install this module if you
-don't plan on using RSS. You can run "perldoc XML::RSS" to see if this
-module is installed.
+L<http://www.cpan.org>. There is not need to install this module if you don't
+plan on using RSS. You can run "perldoc XML::RSS" to see if this module is
+installed.
 
 =item JSON::XS
 
-To support the JSON formated metrics you will need to install JSON::XS, also from
-L<http://www.cpan.org>. There is not need to install this module if you
-don't plan on using JSON formated metrics. You can run "perldoc JSON::XS" to see if this
-module is installed.
+To support the JSON formated metrics you will need to install JSON::XS, also
+from L<http://www.cpan.org>. There is not need to install this module if you
+don't plan on using JSON formated metrics. You can run "perldoc JSON::XS" to
+see if this module is installed.
 
 =item CGI
 
-The CGI Perl module is required for the http/cgi user interface. CGI was a core module,
-but from version 5.22 Perl no longer ships with it so you'll need to install it if you
-are using a recent version of perl.
+The CGI Perl module is required for the http/cgi user interface. CGI was a core
+module, but from version 5.22 Perl no longer ships with it so you'll need to
+install it if you are using a recent version of perl.
 
 =item SCGI
 
-The SCGI Perl module is required to use the S/CGI protocol for the http/cgi user interface.
+The SCGI Perl module is required to use the S/CGI protocol for the http/cgi
+user interface.
 
 =item File::Listing, Net::FTP, Net::FTP::RetrHandle, Net::FTP::AutoReconnect
 
-To use ftp with BackupPC you will need four libraries, but actually
-need to install only File::Listing from L<http://www.cpan.org>.
-You can run "perldoc File::Listing" to see if this module is installed.
-Net::FTP is a standard module. Net::FTP::RetrHandle and
-Net::FTP::AutoReconnect included in BackupPC distribution.
+To use ftp with BackupPC you will need four libraries, but actually need to
+install only File::Listing from L<http://www.cpan.org>. You can run "perldoc
+File::Listing" to see if this module is installed. Net::FTP is a standard
+module. Net::FTP::RetrHandle and Net::FTP::AutoReconnect included in BackupPC
+distribution.
 
 =back
 
-To build and install these packages you should use the cpan command.  At
-the prompt, type
+To build and install these packages you should use the cpan command.  At the
+prompt, type
 
     install BackupPC::XS
 
@@ -1015,71 +982,66 @@ Then run these commands (updating the version number as appropriate):
     make
     make install
 
-Now let's move onto BackupPC itself.  After fetching BackupPC-__VERSION__.tar.gz,
-run these commands as root:
+Now let's move onto BackupPC itself.  After fetching
+BackupPC-__VERSION__.tar.gz, run these commands as root:
 
     tar zxf BackupPC-__VERSION__.tar.gz
     cd BackupPC-__VERSION__
     perl configure.pl
 
-The configure.pl script also accepts command-line options if you
-wish to run it in a non-interactive manner.  It has self-contained
-documentation for all the command-line options, which you can
-read with perldoc:
+The configure.pl script also accepts command-line options if you wish to run it
+in a non-interactive manner.  It has self-contained documentation for all the
+command-line options, which you can read with perldoc:
 
     perldoc configure.pl
 
-Starting with BackupPC 3.0.0, the configure.pl script by default
-complies with the file system hierarchy (FHS) conventions.  The
-major difference compared to earlier versions is that by default
-configuration files will be stored in /etc/BackupPC
-rather than below the data directory, __TOPDIR__/conf,
-and the log files will be stored in /var/log/BackupPC
-rather than below the data directory, __TOPDIR__/log.
+Starting with BackupPC 3.0.0, the configure.pl script by default complies with
+the file system hierarchy (FHS) conventions.  The major difference compared to
+earlier versions is that by default configuration files will be stored in
+/etc/BackupPC rather than below the data directory, __TOPDIR__/conf, and the
+log files will be stored in /var/log/BackupPC rather than below the data
+directory, __TOPDIR__/log.
 
-Note that distributions may choose to use different locations for
-BackupPC files than these defaults.
+Note that distributions may choose to use different locations for BackupPC
+files than these defaults.
 
-If you are upgrading from an earlier version the configure.pl script
-will keep the configuration files and log files in their original
-location.
+If you are upgrading from an earlier version the configure.pl script will keep
+the configuration files and log files in their original location.
 
-When you run configure.pl you will be prompted for the full paths
-of various executables, and you will be prompted for the following
-information.
+When you run configure.pl you will be prompted for the full paths of various
+executables, and you will be prompted for the following information.
 
 =over 4
 
 =item BackupPC User
 
-It is best if BackupPC runs as a special user, eg backuppc, that has
-limited privileges. It is preferred that backuppc belongs to a system
-administrator group so that sysadmin members can browse BackupPC files,
-edit the configuration files and so on. Although configurable, the
-default settings leave group read permission on pool files, so make
-sure the BackupPC user's group is chosen restrictively.
+It is best if BackupPC runs as a special user, eg backuppc, that has limited
+privileges. It is preferred that backuppc belongs to a system administrator
+group so that sysadmin members can browse BackupPC files, edit the
+configuration files and so on. Although configurable, the default settings
+leave group read permission on pool files, so make sure the BackupPC user's
+group is chosen restrictively.
 
 On this installation, this is __BACKUPPCUSER__.
 
-For security purposes you might choose to configure the BackupPC
-user with the shell set to /bin/false.  Since you might need to
-run some BackupPC programs as the BackupPC user for testing
-purposes, you can use the -s option to su to explicitly run
-a shell, eg:
+For security purposes you might choose to configure the BackupPC user with the
+shell set to /bin/false.  Since you might need to run some BackupPC programs as
+the BackupPC user for testing purposes, you can use the -s option to su to
+explicitly run a shell, eg:
 
     su -s /bin/bash __BACKUPPCUSER__
 
 Depending upon your configuration you might also need the -l option.
 
-If the -s option is not available on your operating system, you can
-specify the -m option to use your login shell as invoked shell:
+If the -s option is not available on your operating system, you can specify the
+-m option to use your login shell as invoked shell:
 
     su -m __BACKUPPCUSER__
 
 =item Data Directory
 
-You need to decide where to put the data directory, below which
-all the BackupPC data is stored.  This needs to be a big file system.
+You need to decide where to put the data directory, below which all the
+BackupPC data is stored.  This needs to be a big file system.
 
 On this installation, this is __TOPDIR__.
 
@@ -1092,50 +1054,49 @@ On this installation, this is __INSTALLDIR__.
 
 =item CGI bin Directory
 
-You should decide where the BackupPC CGI script resides.  This will
-usually be below Apache's cgi-bin directory.
+You should decide where the BackupPC CGI script resides.  This will usually be
+below Apache's cgi-bin directory.
 
 It is also possible to use a different directory and use Apache's
-``<Directory>'' directive to specify that location.  See the Apache
-HTTP Server documentation for additional information.
+``<Directory>'' directive to specify that location.  See the Apache HTTP Server
+documentation for additional information.
 
 On this installation, this is __CGIDIR__.
 
 =item Apache image Directory
 
-A directory where BackupPC's images are stored so that Apache can
-serve them.  You should ensure this directory is readable by Apache and
-create a symlink to this directory from the BackupPC CGI bin Directory.
+A directory where BackupPC's images are stored so that Apache can serve them.
+You should ensure this directory is readable by Apache and create a symlink to
+this directory from the BackupPC CGI bin Directory.
 
 =item Config and Log Directories
 
-In this installation the configuration and log directories are
-located in the following locations:
+In this installation the configuration and log directories are located in the
+following locations:
 
     __CONFDIR__/config.pl    main config file
     __CONFDIR__/hosts        hosts file
     __CONFDIR__/pc/HOST.pl   per-pc config file
     __LOGDIR__/BackupPC      log files, pid, status
 
-The configure.pl script doesn't prompt for these locations but
-they can be set for new installations using command-line options.
+The configure.pl script doesn't prompt for these locations but they can be set
+for new installations using command-line options.
 
 =back
 
 =head2 Step 3: Setting up config.pl
 
 After running configure.pl, browse through the config file,
-__CONFDIR__/config.pl, and make sure all the default settings are
-correct. In particular, you will need to decide whether to use
-smb, tar,or rsync or ftp transport (or whether to set it on a
-per-PC basis) and set the relevant parameters for that transport
-method. See the section L<Step 5: Client Setup> for
-more details.
+__CONFDIR__/config.pl, and make sure all the default settings are correct. In
+particular, you will need to decide whether to use smb, tar,or rsync or ftp
+transport (or whether to set it on a per-PC basis) and set the relevant
+parameters for that transport method. See the section L<Step 5: Client Setup>
+for more details.
 
 =head2 Step 4: Setting up the hosts file
 
-The file __CONFDIR__/hosts contains the list of clients to backup.
-BackupPC reads this file in three cases:
+The file __CONFDIR__/hosts contains the list of clients to backup. BackupPC
+reads this file in three cases:
 
 =over 4
 
@@ -1145,53 +1106,49 @@ Upon startup.
 
 =item *
 
-When BackupPC is sent a HUP (-1) signal.  Assuming you installed the
-init.d script, you can also do this with "/etc/init.d/backuppc reload".
+When BackupPC is sent a HUP (-1) signal.  Assuming you installed the init.d
+script, you can also do this with "/etc/init.d/backuppc reload".
 
 =item *
 
-When the modification time of the hosts file changes.  BackupPC
-checks the modification time once during each regular wakeup.
+When the modification time of the hosts file changes.  BackupPC checks the
+modification time once during each regular wakeup.
 
 =back
 
-Whenever you change the hosts file (to add or remove a host) you can
-either do a kill -HUP BackupPC_pid or simply wait until the next regular
-wakeup period.
+Whenever you change the hosts file (to add or remove a host) you can either do
+a kill -HUP BackupPC_pid or simply wait until the next regular wakeup period.
 
-Each line in the hosts file contains three fields, separated
-by whitespace:
+Each line in the hosts file contains three fields, separated by whitespace:
 
 =over 4
 
 =item Host name
 
-This is typically the hostname or NetBios name of the client machine
-and should be in lowercase.  The hostname can contain spaces (escape
-with a backslash), but it is not recommended.
+This is typically the hostname or NetBios name of the client machine and should
+be in lowercase.  The hostname can contain spaces (escape with a backslash),
+but it is not recommended.
 
 Please read the section L<How BackupPC Finds Hosts>.
 
-In certain cases you might want several distinct clients to refer
-to the same physical machine.  For example, you might have a database
-you want to backup, and you want to bracket the backup of the database
-with shutdown/restart using $Conf{DumpPreUserCmd} and $Conf{DumpPostUserCmd}.
-But you also want to backup the rest of the machine while the database
-is still running.  In the case you can specify two different clients in
-the host file, using any mnemonic name (eg: myhost_mysql and myhost), and
-use $Conf{ClientNameAlias} in myhost_mysql's config.pl to specify the
-real hostname of the machine.
+In certain cases you might want several distinct clients to refer to the same
+physical machine.  For example, you might have a database you want to backup,
+and you want to bracket the backup of the database with shutdown/restart using
+$Conf{DumpPreUserCmd} and $Conf{DumpPostUserCmd}. But you also want to backup
+the rest of the machine while the database is still running.  In the case you
+can specify two different clients in the host file, using any mnemonic name
+(eg: myhost_mysql and myhost), and use $Conf{ClientNameAlias} in myhost_mysql's
+config.pl to specify the real hostname of the machine.
 
 =item DHCP flag
 
-Starting with v2.0.0 the way hosts are discovered has changed and now
-in most cases you should specify 0 for the DHCP flag, even if the host
-has a dynamically assigned IP address.
-Please read the section L<How BackupPC Finds Hosts>
-to understand whether you need to set the DHCP flag.
+Starting with v2.0.0 the way hosts are discovered has changed and now in most
+cases you should specify 0 for the DHCP flag, even if the host has a
+dynamically assigned IP address. Please read the section L<How BackupPC Finds
+Hosts> to understand whether you need to set the DHCP flag.
 
-You only need to set DHCP to 1 if your client machine doesn't
-respond to the NetBios multicast request:
+You only need to set DHCP to 1 if your client machine doesn't respond to the
+NetBios multicast request:
 
     nmblookup myHost
 
@@ -1202,29 +1159,29 @@ but does respond to a request directed to its IP address:
 If you do set DHCP to 1 on any client you will need to specify the range of
 DHCP addresses to search is specified in $Conf{DHCPAddressRanges}.
 
-Note also that the $Conf{ClientNameAlias} feature does not work for
-clients with DHCP set to 1.
+Note also that the $Conf{ClientNameAlias} feature does not work for clients
+with DHCP set to 1.
 
 =item User name
 
-This should be the unix login/email name of the user who "owns" or uses
-this machine. This is the user who will be sent email about this
-machine, and this user will have permission to stop/start/browse/restore
-backups for this host.  Leave this blank if no specific person should
-receive email or be allowed to stop/start/browse/restore backups
-for this host.  Administrators will still have full permissions.
+This should be the unix login/email name of the user who "owns" or uses this
+machine. This is the user who will be sent email about this machine, and this
+user will have permission to stop/start/browse/restore backups for this host.
+Leave this blank if no specific person should receive email or be allowed to
+stop/start/browse/restore backups for this host.  Administrators will still
+have full permissions.
 
 =item More users
 
-Additional usernames, separated by commas and with no whitespace,
-can be specified.  These users will also have full permission in
-the CGI interface to stop/start/browse/restore backups for this host.
-These users will not be sent email about this host.
+Additional usernames, separated by commas and with no whitespace, can be
+specified.  These users will also have full permission in the CGI interface to
+stop/start/browse/restore backups for this host. These users will not be sent
+email about this host.
 
 =back
 
-The first non-comment line of the hosts file is special: it contains
-the names of the columns and should not be edited.
+The first non-comment line of the hosts file is special: it contains the names
+of the columns and should not be edited.
 
 Here's a simple example of a hosts file:
 
@@ -1234,19 +1191,17 @@ Here's a simple example of a hosts file:
 
 =head2 Step 5: Client Setup
 
-Four methods for getting backup data from a client are supported:
-smb, tar, rsync and ftp.  Smb or rsync are the preferred methods
-for WinXX clients and rsync or tar are the preferred methods for
-linux/unix/MacOSX clients.
+Four methods for getting backup data from a client are supported: smb, tar,
+rsync and ftp.  Smb or rsync are the preferred methods for WinXX clients and
+rsync or tar are the preferred methods for linux/unix/MacOSX clients.
 
-The transfer method is set using the $Conf{XferMethod} configuration
-setting. If you have a mixed environment (ie: you will use smb for some
-clients and tar for others), you will need to pick the most common
-choice for $Conf{XferMethod} for the main config.pl file, and then
-override it in the per-PC config file for those hosts that will use
-the other method.  (Or you could run two completely separate instances
-of BackupPC, with different data directories, one for WinXX and the
-other for linux/unix, but then common files between the different
+The transfer method is set using the $Conf{XferMethod} configuration setting.
+If you have a mixed environment (ie: you will use smb for some clients and tar
+for others), you will need to pick the most common choice for $Conf{XferMethod}
+for the main config.pl file, and then override it in the per-PC config file for
+those hosts that will use the other method.  (Or you could run two completely
+separate instances of BackupPC, with different data directories, one for WinXX
+and the other for linux/unix, but then common files between the different
 machine types will duplicated.)
 
 Here are some brief client setup notes:
@@ -1255,131 +1210,123 @@ Here are some brief client setup notes:
 
 =item WinXX
 
-One setup for WinXX clients is to set $Conf{XferMethod} to "smb".
-Actually, rsyncd is the better method for WinXX if you are prepared to
-run rsync/cygwin on your WinXX client.
+One setup for WinXX clients is to set $Conf{XferMethod} to "smb". Actually,
+rsyncd is the better method for WinXX if you are prepared to run rsync/cygwin
+on your WinXX client.
 
-If you want to use rsyncd for WinXX clients you can find a pre-packaged
-exe installer on L<https://github.com/backuppc/cygwin-rsyncd/releases>.
-The package is called cygwin-rsync. It contains rsync.exe, template setup files
-and the minimal set of cygwin libraries for everything to run.  The README file
+If you want to use rsyncd for WinXX clients you can find a pre-packaged exe
+installer on L<https://github.com/backuppc/cygwin-rsyncd/releases>. The package
+is called cygwin-rsync. It contains rsync.exe, template setup files and the
+minimal set of cygwin libraries for everything to run.  The README file
 contains instructions for running rsync as a service, so it starts
-automatically everytime you boot your machine.  If you use rsync
-to backup WinXX machines, be sure to set $Conf{ClientCharset}
-correctly (eg: 'cp1252') so that the WinXX filename encoding is
-correctly converted to utf8.
+automatically everytime you boot your machine.  If you use rsync to backup
+WinXX machines, be sure to set $Conf{ClientCharset} correctly (eg: 'cp1252') so
+that the WinXX filename encoding is correctly converted to utf8.
 
-Otherwise, to use SMB, you can either create shares for the data you want
-to backup or your can use the existing C$ share.  To create a new
-share, open "My Computer", right click on the drive (eg: C), and
-select "Sharing..." (or select "Properties" and select the "Sharing"
-tab). In this dialog box you can enable sharing, select the share name
-and permissions.
+Otherwise, to use SMB, you can either create shares for the data you want to
+backup or your can use the existing C$ share.  To create a new share, open "My
+Computer", right click on the drive (eg: C), and select "Sharing..." (or select
+"Properties" and select the "Sharing" tab). In this dialog box you can enable
+sharing, select the share name and permissions.
 
-All Windows NT based OS (NT, 2000, XP Pro), are configured by default
-to share the entire C drive as C$.  This is a special share used for
-various administration functions, one of which is to grant access to backup
-operators. All you need to do is create a new domain user, specifically
-for backup. Then add the new backup user to the built in "Backup
-Operators" group. You now have backup capability for any directory on
-any computer in the domain in one easy step. This avoids using
-administrator accounts and only grants permission to do exactly what you
-want for the given user, i.e.: backup.
-Also, for additional security, you may wish to deny the ability for this
-user to logon to computers in the default domain policy.
+All Windows NT based OS (NT, 2000, XP Pro), are configured by default to share
+the entire C drive as C$.  This is a special share used for various
+administration functions, one of which is to grant access to backup operators.
+All you need to do is create a new domain user, specifically for backup. Then
+add the new backup user to the built in "Backup Operators" group. You now have
+backup capability for any directory on any computer in the domain in one easy
+step. This avoids using administrator accounts and only grants permission to do
+exactly what you want for the given user, i.e.: backup. Also, for additional
+security, you may wish to deny the ability for this user to logon to computers
+in the default domain policy.
 
-If this machine uses DHCP you will also need to make sure the
-NetBios name is set.  Go to Control Panel|System|Network Identification
-(on Win2K) or Control Panel|System|Computer Name (on WinXP).
-Also, you should go to Control Panel|Network Connections|Local Area
-Connection|Properties|Internet Protocol (TCP/IP)|Properties|Advanced|WINS
-and verify that NetBios is not disabled.
+If this machine uses DHCP you will also need to make sure the NetBios name is
+set.  Go to Control Panel|System|Network Identification (on Win2K) or Control
+Panel|System|Computer Name (on WinXP). Also, you should go to Control
+Panel|Network Connections|Local Area Connection|Properties|Internet Protocol
+(TCP/IP)|Properties|Advanced|WINS and verify that NetBios is not disabled.
 
 The relevant configuration settings are $Conf{SmbShareName},
 $Conf{SmbShareUserName}, $Conf{SmbSharePasswd}, $Conf{SmbClientPath},
 $Conf{SmbClientFullCmd}, $Conf{SmbClientIncrCmd} and
 $Conf{SmbClientRestoreCmd}.
 
-BackupPC needs to know the smb share username and password for a
-client machine that uses smb.  The username is specified in
-$Conf{SmbShareUserName}. There are four ways to tell BackupPC the
-smb share password:
+BackupPC needs to know the smb share username and password for a client machine
+that uses smb.  The username is specified in $Conf{SmbShareUserName}. There are
+four ways to tell BackupPC the smb share password:
 
 =over 4
 
 =item *
 
-As an environment variable BPC_SMB_PASSWD set before BackupPC starts.
-If you start BackupPC manually the BPC_SMB_PASSWD variable must be set
-manually first.  For backward compatibility for v1.5.0 and prior, the
-environment variable PASSWD can be used if BPC_SMB_PASSWD is not set.
-Warning: on some systems it is possible to see environment variables of
-running processes.
+As an environment variable BPC_SMB_PASSWD set before BackupPC starts. If you
+start BackupPC manually the BPC_SMB_PASSWD variable must be set manually first.
+ For backward compatibility for v1.5.0 and prior, the environment variable
+PASSWD can be used if BPC_SMB_PASSWD is not set. Warning: on some systems it is
+possible to see environment variables of running processes.
 
 =item *
 
 Alternatively the BPC_SMB_PASSWD setting can be included in
-/etc/init.d/backuppc, in which case you must make sure this file
-is not world (other) readable.
+/etc/init.d/backuppc, in which case you must make sure this file is not world
+(other) readable.
 
 =item *
 
-As a configuration variable $Conf{SmbSharePasswd} in
-__CONFDIR__/config.pl.  If you put the password
-here you must make sure this file is not world (other) readable.
+As a configuration variable $Conf{SmbSharePasswd} in __CONFDIR__/config.pl.  If
+you put the password here you must make sure this file is not world (other)
+readable.
 
 =item *
 
-As a configuration variable $Conf{SmbSharePasswd} in the per-PC
-configuration file (__CONFDIR__/pc/$host.pl or
-__TOPDIR__/pc/$host/config.pl in non-FHS versions of BackupPC).
-You will have to use this option if the smb share password is different
-for each host. If you put the password here you must make sure this file
-is not world (other) readable.
+As a configuration variable $Conf{SmbSharePasswd} in the per-PC configuration
+file (__CONFDIR__/pc/$host.pl or __TOPDIR__/pc/$host/config.pl in non-FHS
+versions of BackupPC). You will have to use this option if the smb share
+password is different for each host. If you put the password here you must make
+sure this file is not world (other) readable.
 
 =back
 
-Placement and protection of the smb share password is a significant
-security issue, so please double-check the file and directory
-permissions.  In a future version there might be support for
-encryption of this password, but a private key will still have to
-be stored in a protected place.  Suggestions are welcome.
+Placement and protection of the smb share password is a significant security
+issue, so please double-check the file and directory permissions.  In a future
+version there might be support for encryption of this password, but a private
+key will still have to be stored in a protected place.  Suggestions are
+welcome.
 
-As an alternative to setting $Conf{XferMethod} to "smb" (using
-smbclient) for WinXX clients, you can use an smb network filesystem (eg:
-ksmbfs or similar) on your linux/unix server to mount the share,
-and then set $Conf{XferMethod} to "tar" (use tar on the network
-mounted file system).
+As an alternative to setting $Conf{XferMethod} to "smb" (using smbclient) for
+WinXX clients, you can use an smb network filesystem (eg: ksmbfs or similar) on
+your linux/unix server to mount the share, and then set $Conf{XferMethod} to
+"tar" (use tar on the network mounted file system).
 
 Also, to make sure that filenames with special characters are correctly
-transferred by smbclient you should make sure that the smb.conf file
-has (for samba 3.x):
+transferred by smbclient you should make sure that the smb.conf file has (for
+samba 3.x):
 
     [global]
 	unix charset = UTF8
 
-UTF8 is the default setting, so if the parameter is missing then it
-is ok.  With this setting $Conf{ClientCharset} should be empty,
-since smbclient has already converted the filenames to utf8.
+UTF8 is the default setting, so if the parameter is missing then it is ok. With
+this setting $Conf{ClientCharset} should be empty, since smbclient has already
+converted the filenames to utf8.
 
 =item Linux/Unix
 
-The preferred setup for linux/unix clients is to set $Conf{XferMethod}
-to "rsync", "rsyncd" or "tar".
+The preferred setup for linux/unix clients is to set $Conf{XferMethod} to
+"rsync", "rsyncd" or "tar".
 
 You can use either rsync, smb, or tar for linux/unix machines. Smb requires
 that the Samba server (smbd) be run to provide the shares. Since the smb
-protocol can't represent special files like symbolic links and fifos,
-tar and rsync are the better transport methods for linux/unix machines.
-(In fact, by default samba makes symbolic links look like the file or
-directory that they point to, so you could get an infinite loop if a
-symbolic link points to the current or parent directory. If you really
-need to use Samba shares for linux/unix backups you should turn off the
-"follow symlinks" samba config setting. See the smb.conf manual page.)
+protocol can't represent special files like symbolic links and fifos, tar and
+rsync are the better transport methods for linux/unix machines. (In fact, by
+default samba makes symbolic links look like the file or directory that they
+point to, so you could get an infinite loop if a symbolic link points to the
+current or parent directory. If you really need to use Samba shares for
+linux/unix backups you should turn off the "follow symlinks" samba config
+setting. See the smb.conf manual page.)
 
-Important note: many linux systems use sparse files for /var/log/lastlog,
-and have large special files below /proc and /run.  Make sure you
-exclude those directories and files when you configure your client.
+Important note: many linux systems use sparse files for /var/log/lastlog, and
+have large special files below /proc and /run.  Make sure you exclude those
+directories and files when you configure your client.
 
 The requirements for each Xfer Method are:
 
@@ -1389,8 +1336,8 @@ The requirements for each Xfer Method are:
 
 To use rsync, you need rsync-bpc installed on the BackupPC server.
 
-On the client, you should have at least rsync 3.x.  Rsync is run on
-the remote client via ssh.
+On the client, you should have at least rsync 3.x.  Rsync is run on the remote
+client via ssh.
 
 The relevant configuration settings are $Conf{RsyncClientPath},
 $Conf{RsyncSshArgs}, $Conf{RsyncShareName}, $Conf{RsyncArgs},
@@ -1400,26 +1347,26 @@ $Conf{RsyncArgsExtra}, $Conf{RsyncFullArgsExtra}, and $Conf{RsyncRestoreArgs}.
 
 To use rsync, you need rsync-bpc installed on the BackupPC server.
 
-On the client, you should have at least rsync 3.x. In this case the
-rsync daemon should be running on the client machine and BackupPC
-connects directly to it.
+On the client, you should have at least rsync 3.x. In this case the rsync
+daemon should be running on the client machine and BackupPC connects directly
+to it.
 
 The relevant configuration settings are $Conf{RsyncBackupPCPath},
 $Conf{RsyncdClientPort}, $Conf{RsyncdUserName}, $Conf{RsyncdPasswd},
 $Conf{RsyncShareName}, $Conf{RsyncArgs}, $Conf{RsyncArgsExtra}, and
-$Conf{RsyncRestoreArgs}. $Conf{RsyncShareName} is the name of an rsync
-module (ie: the thing in square brackets in rsyncd's conf file -- see
-rsyncd.conf), not a file system path.
+$Conf{RsyncRestoreArgs}. $Conf{RsyncShareName} is the name of an rsync module
+(ie: the thing in square brackets in rsyncd's conf file -- see rsyncd.conf),
+not a file system path.
 
-Be aware that rsyncd will remove the leading '/' from path names in
-symbolic links if you specify "use chroot = no" in the rsynd.conf file.
-See the rsyncd.conf manual page for more information.
+Be aware that rsyncd will remove the leading '/' from path names in symbolic
+links if you specify "use chroot = no" in the rsynd.conf file. See the
+rsyncd.conf manual page for more information.
 
 =item tar
 
-You must have GNU tar on the client machine.  Use "tar --version"
-or "gtar --version" to verify.  The version should be at least
-1.13.20.  Tar is run on the client machine via rsh or ssh.
+You must have GNU tar on the client machine.  Use "tar --version" or "gtar
+--version" to verify.  The version should be at least 1.13.20.  Tar is run on
+the client machine via rsh or ssh.
 
 The relevant configuration settings are $Conf{TarClientPath},
 $Conf{TarShareName}, $Conf{TarClientCmd}, $Conf{TarFullArgs},
@@ -1427,207 +1374,192 @@ $Conf{TarIncrArgs}, and $Conf{TarClientRestoreCmd}.
 
 =item ftp
 
-FTP Xfer Method is supported in V4 but not recommended since it only
-handles minimal metadata, it doesn't support hardlinks or special
-files, and can only restore regular files (not symbolic links etc).
+FTP Xfer Method is supported in V4 but not recommended since it only handles
+minimal metadata, it doesn't support hardlinks or special files, and can only
+restore regular files (not symbolic links etc).
 
-You need to be running an ftp server on the client machine.
-The relevant configuration settings are $Conf{FtpShareName},
-$Conf{FtpUserName}, $Conf{FtpPasswd}, $Conf{FtpBlockSize},
-$Conf{FtpPort}, $Conf{FtpTimeout}, and $Conf{FtpFollowSymlinks}.
+You need to be running an ftp server on the client machine. The relevant
+configuration settings are $Conf{FtpShareName}, $Conf{FtpUserName},
+$Conf{FtpPasswd}, $Conf{FtpBlockSize}, $Conf{FtpPort}, $Conf{FtpTimeout}, and
+$Conf{FtpFollowSymlinks}.
 
 =back
 
-You need to set $Conf{ClientCharset} to the client's charset so that
-filenames are correctly converted to utf8.  Use "locale charmap"
-on the client to see its charset.  Note, however, that modern versions
-of smbclient and rsync handle this conversion automatically, so in
-most cases you won't need to set $Conf{ClientCharset}.
+You need to set $Conf{ClientCharset} to the client's charset so that filenames
+are correctly converted to utf8.  Use "locale charmap" on the client to see its
+charset.  Note, however, that modern versions of smbclient and rsync handle
+this conversion automatically, so in most cases you won't need to set
+$Conf{ClientCharset}.
 
-For linux/unix machines you should not backup "/proc".  This directory
-contains a variety of files that look like regular files but they are
-special files that don't need to be backed up (eg: /proc/kcore is a
-regular file that contains physical memory).  See $Conf{BackupFilesExclude}.
-It is safe to backup /dev since it contains mostly character-special
-and block-special files, which are correctly handed by BackupPC
-(eg: backing up /dev/hda5 just saves the block-special file information,
-not the contents of the disk).  Similarly, on many linux systems,
-/var/log/lastlog is a sparse file, with a very large apparent size,
-so you should exclude that too.
+For linux/unix machines you should not backup "/proc".  This directory contains
+a variety of files that look like regular files but they are special files that
+don't need to be backed up (eg: /proc/kcore is a regular file that contains
+physical memory).  See $Conf{BackupFilesExclude}. It is safe to backup /dev
+since it contains mostly character-special and block-special files, which are
+correctly handed by BackupPC (eg: backing up /dev/hda5 just saves the
+block-special file information, not the contents of the disk).  Similarly, on
+many linux systems, /var/log/lastlog is a sparse file, with a very large
+apparent size, so you should exclude that too.
 
-Alternatively, rather than backup all the file systems as a single
-share ("/"), it is easier to restore a single file system if you backup
-each file system separately.  To do this you should list each file system
-mount point in $Conf{TarShareName} or $Conf{RsyncShareName}, and add the
---one-file-system option to $Conf{TarClientCmd} or $Conf{RsyncArgs}.
-In this case there is no need to exclude /proc explicitly since it looks
-like a different file system.
+Alternatively, rather than backup all the file systems as a single share ("/"),
+it is easier to restore a single file system if you backup each file system
+separately.  To do this you should list each file system mount point in
+$Conf{TarShareName} or $Conf{RsyncShareName}, and add the --one-file-system
+option to $Conf{TarClientCmd} or $Conf{RsyncArgs}. In this case there is no
+need to exclude /proc explicitly since it looks like a different file system.
 
-Ssh allows BackupPC to run as a privileged user on the client (eg:
-root), since it needs sufficient permissions to read all the backup
-files.  Ssh is setup so that BackupPC on the server (an otherwise low
-privileged user) can ssh as root on the client, without being prompted
-for a password.  However, directly enabled ssh root logins is not
-good practice.  A better approach is the ssh as a regular user, and
-then configure sudo to allow just rsync to be executed.
+Ssh allows BackupPC to run as a privileged user on the client (eg: root), since
+it needs sufficient permissions to read all the backup files.  Ssh is setup so
+that BackupPC on the server (an otherwise low privileged user) can ssh as root
+on the client, without being prompted for a password.  However, directly
+enabled ssh root logins is not good practice.  A better approach is the ssh as
+a regular user, and then configure sudo to allow just rsync to be executed.
 
-There are two common versions of ssh: v1 and v2. Here are some
-instructions for one way to setup ssh.  (Check which version of SSH
-you have by typing "ssh" or "man ssh".)
+There are two common versions of ssh: v1 and v2. Here are some instructions for
+one way to setup ssh.  (Check which version of SSH you have by typing "ssh" or
+"man ssh".)
 
 =item MacOSX
 
-In general this should be similar to Linux/Unix machines.
-In versions 10.4 and later, the native MacOSX tar works,
-and also supports resource forks.  xtar is another option,
-and rsync works too (although the MacOSX-supplied rsync
-has an extension for extended attributes that is not
-compatible with standard rsync).
+In general this should be similar to Linux/Unix machines. In versions 10.4 and
+later, the native MacOSX tar works, and also supports resource forks.  xtar is
+another option, and rsync works too (although the MacOSX-supplied rsync has an
+extension for extended attributes that is not compatible with standard rsync).
 
 =item SSH Setup
 
-SSH is a secure way to run tar or rsync on a backup client to extract
-the data.  SSH provides strong authentication and encryption of
-the network data.
+SSH is a secure way to run tar or rsync on a backup client to extract the data.
+ SSH provides strong authentication and encryption of the network data.
 
-Note that if you run rsyncd (rsync daemon), ssh is not used.
-In this case, rsyncd provides its own authentication, but there
-is no encryption of network data.  If you want encryption of
-network data you can use ssh to create a tunnel, or use a
-program like stunnel.
+Note that if you run rsyncd (rsync daemon), ssh is not used. In this case,
+rsyncd provides its own authentication, but there is no encryption of network
+data.  If you want encryption of network data you can use ssh to create a
+tunnel, or use a program like stunnel.
 
-Setup instructions for ssh can be found on the
-Wiki at L<https://github.com/backuppc/backuppc/wiki>.
+Setup instructions for ssh can be found on the Wiki at
+L<https://github.com/backuppc/backuppc/wiki>.
 
 =item Clients that use DHCP
 
-If a client machine uses DHCP BackupPC needs some way to find the
-IP address given the hostname.  One alternative is to set dhcp
-to 1 in the hosts file, and BackupPC will search a pool of IP
-addresses looking for hosts.  More efficiently, it is better to
-set dhcp = 0 and provide a mechanism for BackupPC to find the
-IP address given the hostname.
+If a client machine uses DHCP BackupPC needs some way to find the IP address
+given the hostname.  One alternative is to set dhcp to 1 in the hosts file, and
+BackupPC will search a pool of IP addresses looking for hosts.  More
+efficiently, it is better to set dhcp = 0 and provide a mechanism for BackupPC
+to find the IP address given the hostname.
 
-For WinXX machines BackupPC uses the NetBios name server to determine
-the IP address given the hostname.
-For unix machines you can run nmbd (the NetBios name server) from
-the Samba distribution so that the machine responds to a NetBios
-name request. See the manual page and Samba documentation for more
+For WinXX machines BackupPC uses the NetBios name server to determine the IP
+address given the hostname. For unix machines you can run nmbd (the NetBios
+name server) from the Samba distribution so that the machine responds to a
+NetBios name request. See the manual page and Samba documentation for more
 information.
 
-Alternatively, you can set $Conf{NmbLookupFindHostCmd} to any command
-that returns the IP address given the hostname.
+Alternatively, you can set $Conf{NmbLookupFindHostCmd} to any command that
+returns the IP address given the hostname.
 
-Please read the section L<How BackupPC Finds Hosts>
-for more details.
+Please read the section L<How BackupPC Finds Hosts> for more details.
 
 =back
 
 =head2 Step 6: Running BackupPC
 
-The installation contains an init.d backuppc script that can be copied
-to /etc/init.d so that BackupPC can auto-start on boot.
-See init.d/README for further instructions.
+The installation contains an init.d backuppc script that can be copied to
+/etc/init.d so that BackupPC can auto-start on boot. See init.d/README for
+further instructions.
 
-BackupPC should be ready to start.  If you installed the init.d script,
-then you should be able to run BackupPC with:
+BackupPC should be ready to start.  If you installed the init.d script, then
+you should be able to run BackupPC with:
 
     /etc/init.d/backuppc start
 
-(This script can also be invoked with "stop" to stop BackupPC and "reload"
-to tell BackupPC to reload config.pl and the hosts file.)
+(This script can also be invoked with "stop" to stop BackupPC and "reload" to
+tell BackupPC to reload config.pl and the hosts file.)
 
 Otherwise, just run
 
      __INSTALLDIR__/bin/BackupPC -d
 
-as user __BACKUPPCUSER__.  The -d option tells BackupPC to run as a daemon
-(ie: it does an additional fork).
+as user __BACKUPPCUSER__.  The -d option tells BackupPC to run as a daemon (ie:
+it does an additional fork).
 
 Any immediate errors will be printed to stderr and BackupPC will quit.
-Otherwise, look in __LOGDIR__/LOG and verify that BackupPC reports
-it has started and all is ok.
+Otherwise, look in __LOGDIR__/LOG and verify that BackupPC reports it has
+started and all is ok.
 
 =head2 Step 7: Talking to BackupPC
 
-You should verify that BackupPC is running by using BackupPC_serverMesg.
-This sends a message to BackupPC via the unix (or TCP) socket and prints
-the response.  Like all BackupPC programs, BackupPC_serverMesg
-should be run as the BackupPC user (__BACKUPPCUSER__), so you
-should
+You should verify that BackupPC is running by using BackupPC_serverMesg. This
+sends a message to BackupPC via the unix (or TCP) socket and prints the
+response.  Like all BackupPC programs, BackupPC_serverMesg should be run as the
+BackupPC user (__BACKUPPCUSER__), so you should
 
     su __BACKUPPCUSER__
 
-before running BackupPC_serverMesg.  If the BackupPC user is
-configured with /bin/false as the shell, you can use the -s
-option to su to explicitly run a shell, eg:
+before running BackupPC_serverMesg.  If the BackupPC user is configured with
+/bin/false as the shell, you can use the -s option to su to explicitly run a
+shell, eg:
 
     su -s /bin/bash __BACKUPPCUSER__
 
-Depending upon your configuration you might also need
-the -l option.
+Depending upon your configuration you might also need the -l option.
 
-If the -s option is not available on your operating system, you can
-specify the -m option to use your login shell as invoked shell:
+If the -s option is not available on your operating system, you can specify the
+-m option to use your login shell as invoked shell:
 
     su -m __BACKUPPCUSER__
 
 You can request status information and start and stop backups using this
-interface. This socket interface is mainly provided for the CGI interface
-(and some of the BackupPC subprograms use it too).  But right now we just
-want to make sure BackupPC is happy.  Each of these commands should
-produce some status output:
+interface. This socket interface is mainly provided for the CGI interface (and
+some of the BackupPC subprograms use it too).  But right now we just want to
+make sure BackupPC is happy.  Each of these commands should produce some status
+output:
 
     __INSTALLDIR__/bin/BackupPC_serverMesg status info
     __INSTALLDIR__/bin/BackupPC_serverMesg status jobs
     __INSTALLDIR__/bin/BackupPC_serverMesg status hosts
 
-The output should be some hashes printed with Data::Dumper.  If it
-looks cryptic and confusing, and doesn't look like an error message,
-then all is ok.
+The output should be some hashes printed with Data::Dumper.  If it looks
+cryptic and confusing, and doesn't look like an error message, then all is ok.
 
-The hosts status should produce a list of every host you have listed
-in __CONFDIR__/hosts as part of a big cryptic output line.
+The hosts status should produce a list of every host you have listed in
+__CONFDIR__/hosts as part of a big cryptic output line.
 
 You can also request that all hosts be queued:
 
     __INSTALLDIR__/bin/BackupPC_serverMesg backup all
 
-At this point you should make sure the CGI interface works since
-it will be much easier to see what is going on.  We'll get to that
-shortly.
+At this point you should make sure the CGI interface works since it will be
+much easier to see what is going on.  We'll get to that shortly.
 
 =head2 Step 8: Checking email delivery
 
-The script BackupPC_sendEmail sends status and error emails to
-the administrator and users.  It is usually run each night
-by BackupPC_nightly.
+The script BackupPC_sendEmail sends status and error emails to the
+administrator and users.  It is usually run each night by BackupPC_nightly.
 
-To verify that it can run sendmail and deliver email correctly
-you should ask it to send a test email to you:
+To verify that it can run sendmail and deliver email correctly you should ask
+it to send a test email to you:
 
     su __BACKUPPCUSER__
     __INSTALLDIR__/bin/BackupPC_sendEmail -u MYNAME@MYDOMAIN.COM
 
-BackupPC_sendEmail also takes a -c option that checks if BackupPC
-is running, and it sends an email to $Conf{EMailAdminUserName}
-if it is not.  That can be used as a keep-alive check by adding
+BackupPC_sendEmail also takes a -c option that checks if BackupPC is running,
+and it sends an email to $Conf{EMailAdminUserName} if it is not.  That can be
+used as a keep-alive check by adding
 
     __INSTALLDIR__/bin/BackupPC_sendEmail -c
 
 to __BACKUPPCUSER__'s cron.
 
-The -t option to BackupPC_sendEmail causes it to print the email
-message instead of invoking sendmail to deliver the message.
+The -t option to BackupPC_sendEmail causes it to print the email message
+instead of invoking sendmail to deliver the message.
 
-Other options can be added by setting SendMailArgs in __CONFDIR__/config.pl
-or on the email tab of the main configuration editor.
+Other options can be added by setting SendMailArgs in __CONFDIR__/config.pl or
+on the email tab of the main configuration editor.
 
 =head2 Step 9: CGI interface
 
-The CGI interface script, BackupPC_Admin, is a powerful and flexible
-way to see and control what BackupPC is doing.  It is written for an
-Apache server.  If you don't have Apache, see L<http://www.apache.org>.
+The CGI interface script, BackupPC_Admin, is a powerful and flexible way to see
+and control what BackupPC is doing.  It is written for an Apache server.  If
+you don't have Apache, see L<http://www.apache.org>.
 
 There are three options for setting up the CGI interface:
 
@@ -1635,30 +1567,28 @@ There are three options for setting up the CGI interface:
 
 =item SCGI
 
-New to 4.x, SCGI uses the SCGI interface to Apache, which requires
-the mod_scgi.so module to be installed and loaded by Apache.  This
-allows Apache to run as any unprivileged user.  The actual SCGI
-server runs as the as the BackupPC user (__BACKUPPCUSER__), and
-handles the requests from Apache via a TCP socket.
+New to 4.x, SCGI uses the SCGI interface to Apache, which requires the
+mod_scgi.so module to be installed and loaded by Apache.  This allows Apache to
+run as any unprivileged user.  The actual SCGI server runs as the as the
+BackupPC user (__BACKUPPCUSER__), and handles the requests from Apache via a
+TCP socket.
 
 =item mod_perl
 
-Mod_perl required the mod_perl module to be loaded by Apache.  This
-allows BackupPC_Admin to be run from inside Apache.  Unlike SCGI,
-using mod_perl with BackupPC_Admin requires a dedicated Apache to
-be run as the BackupPC user (__BACKUPPCUSER__).  This is because
-BackupPC_Admin needs permission to access various files in BackupPC's
-data directories.
+Mod_perl required the mod_perl module to be loaded by Apache.  This allows
+BackupPC_Admin to be run from inside Apache.  Unlike SCGI, using mod_perl with
+BackupPC_Admin requires a dedicated Apache to be run as the BackupPC user
+(__BACKUPPCUSER__).  This is because BackupPC_Admin needs permission to access
+various files in BackupPC's data directories.
 
 =item standard
 
-The standard mode, which is significantly slower than SCGI or
-mod_perl, is where Apache runs BackupPC_Admin as a separate process
-for every request.  This adds significant startup overhead for every
-request, and also requires that BackupPC_Admin be run as setuid to
-the BackupPC user (__BACKUPPCUSER__), if Apache isn't being run as
-that user.  Setuid scripts are discouraged, so the preference is to
-use SCGI or mod_perl.
+The standard mode, which is significantly slower than SCGI or mod_perl, is
+where Apache runs BackupPC_Admin as a separate process for every request.  This
+adds significant startup overhead for every request, and also requires that
+BackupPC_Admin be run as setuid to the BackupPC user (__BACKUPPCUSER__), if
+Apache isn't being run as that user.  Setuid scripts are discouraged, so the
+preference is to use SCGI or mod_perl.
 
 =back
 
@@ -1668,17 +1598,17 @@ Here are some specifics for each setup:
 
 =item SCGI Setup
 
-First you need to install mod_scgi.  If you can't find a pre-built
-package, the source is available at L<http://python.ca/scgi>.  The
-release has subdirectories for apache1 and apache2.  Pick your
-matching version (nowadays most likely apache2).  You'll need apxs,
-the Apache Extension Tool, installed to build from source.  Once
-compiled, the module mod_scgi.so should be installed via the Makefile.
+First you need to install mod_scgi.  If you can't find a pre-built package, the
+source is available at L<http://python.ca/scgi>.  The release has
+subdirectories for apache1 and apache2.  Pick your matching version (nowadays
+most likely apache2).  You'll need apxs, the Apache Extension Tool, installed
+to build from source.  Once compiled, the module mod_scgi.so should be
+installed via the Makefile.
 
 To enable the SCGI server, set $Conf{SCGIServerPort} to an available
-non-privileged TCP port number, eg: 10268.  The matching port number
-has to appear in the Apache configuration file.  Typical Apache
-configuration entries will look like this:
+non-privileged TCP port number, eg: 10268.  The matching port number has to
+appear in the Apache configuration file.  Typical Apache configuration entries
+will look like this:
 
     LoadModule scgi_module modules/mod_scgi.so
     SCGIMount /BackupPC_Admin 127.0.0.1:10268
@@ -1715,48 +1645,44 @@ This allows the SCGI interface to be accessed with a URL:
 
     http://yourBackupPCServerHost/BackupPC_Admin
 
-You can use a different path or name if you prefer a different URL.
-Unlike traditional CGI, there is no need to specify a valid path to
-a CGI script.
+You can use a different path or name if you prefer a different URL. Unlike
+traditional CGI, there is no need to specify a valid path to a CGI script.
 
-Important security warning!!  The SCGIServerPort must not be
-accessible by anyone untrusted.  That means you can't allow
-untrusted users access to the BackupPC server, and you should
-block the SCGIServerPort TCP port on the BackupPC server.  If you
-don't understand what that means, or can't confirm you have
-configured SCGI securely, then don't enable SCGI - use one of
-the following two methods!!
+Important security warning!!  The SCGIServerPort must not be accessible by
+anyone untrusted.  That means you can't allow untrusted users access to the
+BackupPC server, and you should block the SCGIServerPort TCP port on the
+BackupPC server.  If you don't understand what that means, or can't confirm you
+have configured SCGI securely, then don't enable SCGI - use one of the
+following two methods!!
 
 =item Mod_perl Setup
 
-The advantage of the mod_perl setup is that no setuid script is
-needed (like in the standard method below), and there is a significant
-performance advantage.  Not only does all the perl code need to be
-parsed just once, the config.pl and hosts files, plus the connection
-to the BackupPC server are cached between requests.  The typical
-speedup is around 10-15x.
+The advantage of the mod_perl setup is that no setuid script is needed (like in
+the standard method below), and there is a significant performance advantage.
+Not only does all the perl code need to be parsed just once, the config.pl and
+hosts files, plus the connection to the BackupPC server are cached between
+requests.  The typical speedup is around 10-15x.
 
-To use mod_perl you need to run Apache as user __BACKUPPCUSER__.
-If you need to run multiple Apaches for different services then
-you need to create multiple top-level Apache directories, each
-with their own config file.  You can make copies of /etc/init.d/httpd
-and use the -d option to httpd to point each http to a different
-top-level directory.  Or you can use the -f option to explicitly
-point to the config file.  Multiple Apache's will run on different
-Ports (eg: 80 is standard, 8080 is a typical alternative port accessed
-via http://yourhost.com:8080).
+To use mod_perl you need to run Apache as user __BACKUPPCUSER__. If you need to
+run multiple Apaches for different services then you need to create multiple
+top-level Apache directories, each with their own config file.  You can make
+copies of /etc/init.d/httpd and use the -d option to httpd to point each http
+to a different top-level directory.  Or you can use the -f option to explicitly
+point to the config file.  Multiple Apache's will run on different Ports (eg:
+80 is standard, 8080 is a typical alternative port accessed via
+http://yourhost.com:8080).
 
-Inside BackupPC's Apache http.conf file you should check the
-settings for ServerRoot, DocumentRoot, User, Group, and Port.  See
+Inside BackupPC's Apache http.conf file you should check the settings for
+ServerRoot, DocumentRoot, User, Group, and Port.  See
 L<http://httpd.apache.org/docs/server-wide.html> for more details.
 
-For mod_perl, BackupPC_Admin should not have setuid permission, so
-you should turn it off:
+For mod_perl, BackupPC_Admin should not have setuid permission, so you should
+turn it off:
 
     chmod u-s __CGIDIR__/BackupPC_Admin
 
-To tell Apache to use mod_perl to execute BackupPC_Admin, add this
-to Apache's 1.x httpd.conf file:
+To tell Apache to use mod_perl to execute BackupPC_Admin, add this to Apache's
+1.x httpd.conf file:
 
     <IfModule mod_perl.c>
 	PerlModule Apache::Registry
@@ -1769,8 +1695,8 @@ to Apache's 1.x httpd.conf file:
 	</Location>
     </IfModule>
 
-Apache 2.0.44 with Perl 5.8.0 on RedHat 7.1, Don Silvia reports that
-this works (with tweaks from Michael Tuzi):
+Apache 2.0.44 with Perl 5.8.0 on RedHat 7.1, Don Silvia reports that this works
+(with tweaks from Michael Tuzi):
 
     LoadModule perl_module modules/mod_perl.so
     PerlModule Apache2
@@ -1789,52 +1715,48 @@ this works (with tweaks from Michael Tuzi):
 	Require valid-user
     </Directory>
 
-There are other optimizations and options with mod_perl.  For
-example, you can tell mod_perl to preload various perl modules,
-which saves memory compared to loading separate copies in every
-Apache process after they are forked.  See Stas's definitive
-mod_perl guide at L<http://perl.apache.org/guide>.
+There are other optimizations and options with mod_perl.  For example, you can
+tell mod_perl to preload various perl modules, which saves memory compared to
+loading separate copies in every Apache process after they are forked.  See
+Stas's definitive mod_perl guide at L<http://perl.apache.org/guide>.
 
 =item Standard Setup
 
-The CGI interface should have been installed by the configure.pl script
-in __CGIDIR__/BackupPC_Admin.  BackupPC_Admin should have been installed
-as setuid to the BackupPC user (__BACKUPPCUSER__), in addition to user
-and group execute permission.
+The CGI interface should have been installed by the configure.pl script in
+__CGIDIR__/BackupPC_Admin.  BackupPC_Admin should have been installed as setuid
+to the BackupPC user (__BACKUPPCUSER__), in addition to user and group execute
+permission.
 
-You should be very careful about permissions on BackupPC_Admin and
-the directory __CGIDIR__: it is important that normal users cannot
-directly execute or change BackupPC_Admin, otherwise they can access
-backup files for any PC. You might need to change the group ownership
-of BackupPC_Admin to a group that Apache belongs to so that Apache
-can execute it (don't add "other" execute permission!).
-The permissions should look like this:
+You should be very careful about permissions on BackupPC_Admin and the
+directory __CGIDIR__: it is important that normal users cannot directly execute
+or change BackupPC_Admin, otherwise they can access backup files for any PC.
+You might need to change the group ownership of BackupPC_Admin to a group that
+Apache belongs to so that Apache can execute it (don't add "other" execute
+permission!). The permissions should look like this:
 
     ls -l __CGIDIR__/BackupPC_Admin
     -swxr-x---    1 __BACKUPPCUSER__   web      82406 Jun 17 22:58 __CGIDIR__/BackupPC_Admin
 
-The setuid script won't work unless perl on your machine was installed
-with setuid emulation.  This is likely the problem if you get an error
-saying such as "Wrong user: my userid is 25, instead of 150", meaning
-the script is running as the httpd user, not the BackupPC user.
-This is because setuid scripts are disabled by the kernel in most
-flavors of unix and linux.
+The setuid script won't work unless perl on your machine was installed with
+setuid emulation.  This is likely the problem if you get an error saying such
+as "Wrong user: my userid is 25, instead of 150", meaning the script is running
+as the httpd user, not the BackupPC user. This is because setuid scripts are
+disabled by the kernel in most flavors of unix and linux.
 
-To see if your perl has setuid emulation, see if there is a program
-called sperl5.8.0 (or sperl5.8.2 etc, based on your perl version)
-in the place where perl is installed. If you can't find this program,
-then you have two options: rebuild and reinstall perl with the setuid
-emulation turned on (answer "y" to the question "Do you want to do
-setuid/setgid emulation?" when you run perl's configure script), or
-switch to the mod_perl alternative for the CGI script (which doesn't
-need setuid to work).
+To see if your perl has setuid emulation, see if there is a program called
+sperl5.8.0 (or sperl5.8.2 etc, based on your perl version) in the place where
+perl is installed. If you can't find this program, then you have two options:
+rebuild and reinstall perl with the setuid emulation turned on (answer "y" to
+the question "Do you want to do setuid/setgid emulation?" when you run perl's
+configure script), or switch to the mod_perl alternative for the CGI script
+(which doesn't need setuid to work).
 
 =back
 
-BackupPC_Admin requires that users are authenticated by Apache.
-Specifically, it expects that Apache sets the REMOTE_USER environment
-variable when it runs.  There are several ways to do this.  One way
-is to create a .htaccess file in the cgi-bin directory that looks like:
+BackupPC_Admin requires that users are authenticated by Apache. Specifically,
+it expects that Apache sets the REMOTE_USER environment variable when it runs.
+There are several ways to do this.  One way is to create a .htaccess file in
+the cgi-bin directory that looks like:
 
     AuthGroupFile /etc/httpd/conf/group    # <--- change path as needed
     AuthUserFile /etc/http/conf/passwd     # <--- change path as needed
@@ -1842,11 +1764,10 @@ is to create a .htaccess file in the cgi-bin directory that looks like:
     AuthName "access"
     require valid-user
 
-You will also need "AllowOverride Indexes AuthConfig" in the Apache
-httpd.conf file to enable the .htaccess file. Alternatively, everything
-can go in the Apache httpd.conf file inside a Location directive. The
-list of users and password file above can be extracted from the NIS
-passwd file.
+You will also need "AllowOverride Indexes AuthConfig" in the Apache httpd.conf
+file to enable the .htaccess file. Alternatively, everything can go in the
+Apache httpd.conf file inside a Location directive. The list of users and
+password file above can be extracted from the NIS passwd file.
 
 One alternative is to use LDAP.  In Apache's http.conf add these lines:
 
@@ -1862,35 +1783,35 @@ One alternative is to use LDAP.  In Apache's http.conf add these lines:
       require valid-user
     </Location>
 
-If you want to disable the user authentication you can set
-$Conf{CgiAdminUsers} to '*', which allows any user to have
-full access to all hosts and backups.  In this case the REMOTE_USER
-environment variable does not have to be set by Apache.
+If you want to disable the user authentication you can set $Conf{CgiAdminUsers}
+to '*', which allows any user to have full access to all hosts and backups.  In
+this case the REMOTE_USER environment variable does not have to be set by
+Apache.
 
-Alternatively, you can force a particular username by getting Apache
-to set REMOTE_USER, eg, to hard code the user to www you could add
-this to Apache's httpd.conf:
+Alternatively, you can force a particular username by getting Apache to set
+REMOTE_USER, eg, to hard code the user to www you could add this to Apache's
+httpd.conf:
 
     <Location /cgi-bin/BackupPC/BackupPC_Admin>   # <--- change path as needed
         Setenv REMOTE_USER www
     </Location>
 
-Finally, you should also edit the config.pl file and adjust, as necessary,
-the CGI-specific settings.  They're near the end of the config file. In
-particular, you should specify which users or groups have administrator
-(privileged) access: see the config settings $Conf{CgiAdminUserGroup}
-and $Conf{CgiAdminUsers}.  Also, the configure.pl script placed various
-images into $Conf{CgiImageDir} that BackupPC_Admin needs to serve
-up.  You should make sure that $Conf{CgiImageDirURL} is the correct
-URL for the image directory.
+Finally, you should also edit the config.pl file and adjust, as necessary, the
+CGI-specific settings.  They're near the end of the config file. In particular,
+you should specify which users or groups have administrator (privileged)
+access: see the config settings $Conf{CgiAdminUserGroup} and
+$Conf{CgiAdminUsers}.  Also, the configure.pl script placed various images into
+$Conf{CgiImageDir} that BackupPC_Admin needs to serve up.  You should make sure
+that $Conf{CgiImageDirURL} is the correct URL for the image directory.
 
-See the section L<Fixing installation problems> for suggestions on debugging the Apache authentication setup.
+See the section L<Fixing installation problems> for suggestions on debugging
+the Apache authentication setup.
 
 =head2 How BackupPC Finds Hosts
 
-Starting with v2.0.0 the way hosts are discovered has changed.  In most
-cases you should specify 0 for the DHCP flag in the conf/hosts file,
-even if the host has a dynamically assigned IP address.
+Starting with v2.0.0 the way hosts are discovered has changed.  In most cases
+you should specify 0 for the DHCP flag in the conf/hosts file, even if the host
+has a dynamically assigned IP address.
 
 BackupPC (starting with v2.0.0) looks up hosts with DHCP = 0 in this manner:
 
@@ -1898,20 +1819,19 @@ BackupPC (starting with v2.0.0) looks up hosts with DHCP = 0 in this manner:
 
 =item *
 
-First DNS is used to lookup the IP address given the client's name
-using perl's gethostbyname() function.  This should succeed for machines
-that have fixed IP addresses that are known via DNS.  You can manually
-see whether a given host have a DNS entry according to perl's
-gethostbyname function with this command:
+First DNS is used to lookup the IP address given the client's name using perl's
+gethostbyname() function.  This should succeed for machines that have fixed IP
+addresses that are known via DNS.  You can manually see whether a given host
+have a DNS entry according to perl's gethostbyname function with this command:
 
     perl -e 'print(gethostbyname("myhost") ? "ok\n" : "not found\n");'
 
 =item *
 
-If gethostbyname() fails, BackupPC then attempts a NetBios multicast to
-find the host.  Provided your client machine is configured properly,
-it should respond to this NetBios multicast request.  Specifically,
-BackupPC runs a command of this form:
+If gethostbyname() fails, BackupPC then attempts a NetBios multicast to find
+the host.  Provided your client machine is configured properly, it should
+respond to this NetBios multicast request.  Specifically, BackupPC runs a
+command of this form:
 
     nmblookup myhost
 
@@ -1925,39 +1845,39 @@ If it is successful you will see output like:
     querying myhost on 10.10.255.255
     10.10.1.73 myhost<00>
 
-Depending on your netmask you might need to specify the -B option to
-nmblookup.  For example:
+Depending on your netmask you might need to specify the -B option to nmblookup.
+ For example:
 
     nmblookup -B 10.10.1.255 myhost
 
-If necessary, experiment with the nmblookup command which will return the
-IP address of the client given its name.  Then update
-$Conf{NmbLookupFindHostCmd} with any necessary options to nmblookup.
+If necessary, experiment with the nmblookup command which will return the IP
+address of the client given its name.  Then update $Conf{NmbLookupFindHostCmd}
+with any necessary options to nmblookup.
 
 =back
 
-For hosts that have the DHCP flag set to 1, these machines are
-discovered as follows:
+For hosts that have the DHCP flag set to 1, these machines are discovered as
+follows:
 
 =over 4
 
 =item *
 
-A DHCP address pool ($Conf{DHCPAddressRanges}) needs to be specified.
-BackupPC will check the NetBIOS name of each machine in the range using
-a command of the form:
+A DHCP address pool ($Conf{DHCPAddressRanges}) needs to be specified. BackupPC
+will check the NetBIOS name of each machine in the range using a command of the
+form:
 
     nmblookup -A W.X.Y.Z
 
-where W.X.Y.Z is each candidate address from $Conf{DHCPAddressRanges}.
-Any host that has a valid NetBIOS name returned by this command (ie:
-matching an entry in the hosts file) will be backed up.  You can
-modify the specific nmblookup command if necessary via $Conf{NmbLookupCmd}.
+where W.X.Y.Z is each candidate address from $Conf{DHCPAddressRanges}. Any host
+that has a valid NetBIOS name returned by this command (ie: matching an entry
+in the hosts file) will be backed up.  You can modify the specific nmblookup
+command if necessary via $Conf{NmbLookupCmd}.
 
 =item *
 
-You only need to use this DHCP feature if your client machine doesn't
-respond to the NetBios multicast request:
+You only need to use this DHCP feature if your client machine doesn't respond
+to the NetBios multicast request:
 
     nmblookup myHost
 
@@ -1974,160 +1894,148 @@ but does respond to a request directed to its IP address:
 =item Removing a client
 
 If there is a machine that no longer needs to be backed up (eg: a retired
-machine) you have two choices.  First, you can keep the backups accessible
-and browsable, but disable all new backups.  Alternatively, you can
-completely remove the client and all its backups.
+machine) you have two choices.  First, you can keep the backups accessible and
+browsable, but disable all new backups.  Alternatively, you can completely
+remove the client and all its backups.
 
-To disable backups for a client $Conf{BackupsDisable} can be
-set to two different values in that client's per-PC config.pl file:
+To disable backups for a client $Conf{BackupsDisable} can be set to two
+different values in that client's per-PC config.pl file:
 
 =over 4
 
 =item 1
 
-Don't do any regular backups on this machine.  Manually
-requested backups (via the CGI interface) will still occur.
+Don't do any regular backups on this machine.  Manually requested backups (via
+the CGI interface) will still occur.
 
 =item 2
 
-Don't do any backups on this machine.  Manually requested
-backups (via the CGI interface) will be ignored.
+Don't do any backups on this machine.  Manually requested backups (via the CGI
+interface) will be ignored.
 
 =back
 
-This will still allow the client's old backups to be browsable
-and restorable.
+This will still allow the client's old backups to be browsable and restorable.
 
-To completely remove a client and all its backups, you should remove its
-entry in the conf/hosts file, and then delete the __TOPDIR__/pc/$host
-directory.  Whenever you change the hosts file, you should send
-BackupPC a HUP (-1) signal so that it re-reads the hosts file.
-If you don't do this, BackupPC will automatically re-read the
-hosts file at the next regular wakeup.
+To completely remove a client and all its backups, you should remove its entry
+in the conf/hosts file, and then delete the __TOPDIR__/pc/$host directory.
+Whenever you change the hosts file, you should send BackupPC a HUP (-1) signal
+so that it re-reads the hosts file. If you don't do this, BackupPC will
+automatically re-read the hosts file at the next regular wakeup.
 
-Note that when you remove a client's backups you won't initially
-recover much disk space.  That's because the client's files are
-still in the pool.  Overnight, when BackupPC_nightly next runs,
-all the unused pool files will be deleted and this will recover
-the disk space used by the client's backups.
+Note that when you remove a client's backups you won't initially recover much
+disk space.  That's because the client's files are still in the pool.
+Overnight, when BackupPC_nightly next runs, all the unused pool files will be
+deleted and this will recover the disk space used by the client's backups.
 
 =item Copying the pool
 
-If the pool disk requirements grow you might need to copy the entire
-data directory to a new (bigger) file system.  Hopefully you are lucky
-enough to avoid this by having the data directory on a RAID file system
-or LVM that allows the capacity to be grown in place by adding disks.
+If the pool disk requirements grow you might need to copy the entire data
+directory to a new (bigger) file system.  Hopefully you are lucky enough to
+avoid this by having the data directory on a RAID file system or LVM that
+allows the capacity to be grown in place by adding disks.
 
-Backups prior to V4 make extensive use of hardlinks.  So unless you have
-a virgin V4 installation, your file system will contain large numbers
-of hardlinks.  This makes it hard to copy.
+Backups prior to V4 make extensive use of hardlinks.  So unless you have a
+virgin V4 installation, your file system will contain large numbers of
+hardlinks.  This makes it hard to copy.
 
-Prior to V4 (or a V4 upgrade to a V3 installation), the backup data
-directories contain large numbers of hardlinks.  If you try to copy
-the pool the target directory will occupy a lot more space if the
-hardlinks aren't re-established.
+Prior to V4 (or a V4 upgrade to a V3 installation), the backup data directories
+contain large numbers of hardlinks.  If you try to copy the pool the target
+directory will occupy a lot more space if the hardlinks aren't re-established.
 
-Unless you have a pure V4 installation, the best way to copy a pool
-file system, if possible, is by copying the raw device at the block
-level (eg: using dd).  Application level programs that understand
-hardlinks include the GNU cp program with the -a option and rsync -H.
-However, the large number of hardlinks in the pool will make the
-memory usage large and the copy very slow.  Don't forget to stop
-BackupPC while the copy runs.
+Unless you have a pure V4 installation, the best way to copy a pool file
+system, if possible, is by copying the raw device at the block level (eg: using
+dd).  Application level programs that understand hardlinks include the GNU cp
+program with the -a option and rsync -H. However, the large number of hardlinks
+in the pool will make the memory usage large and the copy very slow.  Don't
+forget to stop BackupPC while the copy runs.
 
-If you have a pure V4 installation, copying the pool and PC backup
-directories should be quite easy.  Rsync 3.x should work well.
+If you have a pure V4 installation, copying the pool and PC backup directories
+should be quite easy.  Rsync 3.x should work well.
 
 =back
 
 =head2 Fixing installation problems
 
-If you find a solution to your problem that could help other users
-please add it to the Wiki at L<https://github.com/backuppc/backuppc/wiki>.
+If you find a solution to your problem that could help other users please add
+it to the Wiki at L<https://github.com/backuppc/backuppc/wiki>.
 
 =head1 Restore functions
 
-BackupPC supports several different methods for restoring files. The
-most convenient restore options are provided via the CGI interface.
-Alternatively, backup files can be restored using manual commands.
+BackupPC supports several different methods for restoring files. The most
+convenient restore options are provided via the CGI interface. Alternatively,
+backup files can be restored using manual commands.
 
 =head2 CGI restore options
 
-By selecting a host in the CGI interface, a list of all the backups
-for that machine will be displayed.  By selecting the backup number
-you can navigate the shares and directory tree for that backup.
+By selecting a host in the CGI interface, a list of all the backups for that
+machine will be displayed.  By selecting the backup number you can navigate the
+shares and directory tree for that backup.
 
-BackupPC's CGI interface automatically fills incremental backups
-with the corresponding full backup, which means each backup has
-a filled appearance.  Therefore, there is no need to do multiple
-restores from the incremental and full backups: BackupPC does all
-the hard work for you.  You simply select the files and directories
-you want from the correct backup vintage in one step.
+BackupPC's CGI interface automatically fills incremental backups with the
+corresponding full backup, which means each backup has a filled appearance.
+Therefore, there is no need to do multiple restores from the incremental and
+full backups: BackupPC does all the hard work for you.  You simply select the
+files and directories you want from the correct backup vintage in one step.
 
-You can download a single backup file at any time simply by selecting
-it.  Your browser should prompt you with the filename and ask you
-whether to open the file or save it to disk.
+You can download a single backup file at any time simply by selecting it.  Your
+browser should prompt you with the filename and ask you whether to open the
+file or save it to disk.
 
-Alternatively, you can select one or more files or directories in
-the currently selected directory and select "Restore selected files".
-(If you need to restore selected files and directories from several
-different parent directories you will need to do that in multiple
-steps.)
+Alternatively, you can select one or more files or directories in the currently
+selected directory and select "Restore selected files". (If you need to restore
+selected files and directories from several different parent directories you
+will need to do that in multiple steps.)
 
-If you select all the files in a directory, BackupPC will replace
-the list of files with the parent directory.  You will be presented
-with a screen that has three options:
+If you select all the files in a directory, BackupPC will replace the list of
+files with the parent directory.  You will be presented with a screen that has
+three options:
 
 =over 4
 
 =item Option 1: Direct Restore
 
-With this option the selected files and directories are restored
-directly back onto the host, by default in their original location.
-Any old files with the same name will be overwritten, so use caution.
-You can optionally change the target hostname, target share name,
-and target path prefix for the restore, allowing you to restore the
-files to a different location.
+With this option the selected files and directories are restored directly back
+onto the host, by default in their original location. Any old files with the
+same name will be overwritten, so use caution. You can optionally change the
+target hostname, target share name, and target path prefix for the restore,
+allowing you to restore the files to a different location.
 
-Once you select "Start Restore" you will be prompted one last time
-with a summary of the exact source and target files and directories
-before you commit.  When you give the final go ahead the restore
-operation will be queued like a normal backup job, meaning that it
-will be deferred if there is a backup currently running for that host.
-When the restore job is run, smbclient, tar, rsync or rsyncd is used
-(depending upon $Conf{XferMethod}) to actually restore the files.
-Sorry, there is currently no option to cancel a restore that has been
-started.  Currently ftp restores are not fully implemented.
+Once you select "Start Restore" you will be prompted one last time with a
+summary of the exact source and target files and directories before you commit.
+ When you give the final go ahead the restore operation will be queued like a
+normal backup job, meaning that it will be deferred if there is a backup
+currently running for that host. When the restore job is run, smbclient, tar,
+rsync or rsyncd is used (depending upon $Conf{XferMethod}) to actually restore
+the files. Sorry, there is currently no option to cancel a restore that has
+been started.  Currently ftp restores are not fully implemented.
 
-A record of the restore request, including the result and list of
-files and directories, is kept.  It can be browsed from the host's
-home page.  $Conf{RestoreInfoKeepCnt} specifies how many old restore
-status files to keep.
+A record of the restore request, including the result and list of files and
+directories, is kept.  It can be browsed from the host's home page.
+$Conf{RestoreInfoKeepCnt} specifies how many old restore status files to keep.
 
-Note that for direct restore to work, the $Conf{XferMethod} must
-be able to write to the client.  For example, that means an SMB
-share for smbclient needs to be writable, and the rsyncd module
-needs "read only" set to "false".  This creates additional security
-risks.  If you only create read-only SMB shares (which is a good
-idea), then the direct restore will fail.  You can disable the
+Note that for direct restore to work, the $Conf{XferMethod} must be able to
+write to the client.  For example, that means an SMB share for smbclient needs
+to be writable, and the rsyncd module needs "read only" set to "false".  This
+creates additional security risks.  If you only create read-only SMB shares
+(which is a good idea), then the direct restore will fail.  You can disable the
 direct restore option by setting $Conf{SmbClientRestoreCmd},
 $Conf{TarClientRestoreCmd} and $Conf{RsyncRestoreArgs} to undef.
 
 =item Option 2: Download Zip archive
 
-With this option a zip file containing the selected files and directories
-is downloaded.  The zip file can then be unpacked or individual files
-extracted as necessary on the host machine. The compression level can be
-specified.  A value of 0 turns off compression.
+With this option a zip file containing the selected files and directories is
+downloaded.  The zip file can then be unpacked or individual files extracted as
+necessary on the host machine. The compression level can be specified.  A value
+of 0 turns off compression.
 
-When you select "Download Zip File" you should be prompted where to
-save the restore.zip file.
+When you select "Download Zip File" you should be prompted where to save the
+restore.zip file.
 
-BackupPC does not consider downloading a zip file as an actual
-restore operation, so the details are not saved for later browsing
-as in the first case.  However, a mention that a zip file was
-downloaded by a particular user, and a list of the files, does
-appear in BackupPC's log file.
+BackupPC does not consider downloading a zip file as an actual restore
+operation, so the details are not saved for later browsing as in the first
+case.  However, a mention that a zip file was downloaded by a particular user,
+and a list of the files, does appear in BackupPC's log file.
 
 =item Option 3: Download Tar archive
 
@@ -2138,24 +2046,21 @@ rather than a zip file (and there is currently no compression option).
 
 =head2 Command-line restore options
 
-Apart from the CGI interface, BackupPC allows you to restore files
-and directories from the command line.  The following programs can
-be used:
+Apart from the CGI interface, BackupPC allows you to restore files and
+directories from the command line.  The following programs can be used:
 
 =over 4
 
 =item BackupPC_zcat
 
-For each filename argument it inflates (uncompresses) the file and
-writes it to stdout.  To use BackupPC_zcat you could give it the
-full filename, eg:
+For each filename argument it inflates (uncompresses) the file and writes it to
+stdout.  To use BackupPC_zcat you could give it the full filename, eg:
 
     __INSTALLDIR__/bin/BackupPC_zcat __TOPDIR__/pc/host/5/fc/fcraig/fexample.txt > example.txt
 
 It's your responsibility to make sure the file is really compressed:
 BackupPC_zcat doesn't check which backup the requested file is from.
-BackupPC_zcat returns a nonzero status if it fails to uncompress
-a file.
+BackupPC_zcat returns a nonzero status if it fails to uncompress a file.
 
 In V4, BackupPC_zcat can be invoked in several other ways:
 
@@ -2181,10 +2086,10 @@ You can also mix real paths with unmangled paths.  Both of these versions work:
 
 =item BackupPC_tarCreate
 
-BackupPC_tarCreate creates a tar file for any files or directories in
-a particular backup.  Merging of incrementals is done automatically,
-so you don't need to worry about whether certain files appear in the
-incremental or full backup.
+BackupPC_tarCreate creates a tar file for any files or directories in a
+particular backup.  Merging of incrementals is done automatically, so you don't
+need to worry about whether certain files appear in the incremental or full
+backup.
 
 The usage is:
 
@@ -2208,20 +2113,20 @@ The usage is:
        -l              just print a file listing; don't generate an archive
        -L              just print a detailed file listing; don't generate an archive
 
-The command-line files and directories are relative to the specified
-shareName.  The tar file is written to stdout.
+The command-line files and directories are relative to the specified shareName.
+ The tar file is written to stdout.
 
-The -h, -n and -s options specify which dump is used to generate
-the tar archive.  The -r and -p options can be used to relocate
-the paths in the tar archive so extracted files can be placed
-in a location different from their original location.
+The -h, -n and -s options specify which dump is used to generate the tar
+archive.  The -r and -p options can be used to relocate the paths in the tar
+archive so extracted files can be placed in a location different from their
+original location.
 
 =item BackupPC_zipCreate
 
-BackupPC_zipCreate creates a zip file for any files or directories in
-a particular backup.  Merging of incrementals is done automatically,
-so you don't need to worry about whether certain files appear in the
-incremental or full backup.
+BackupPC_zipCreate creates a zip file for any files or directories in a
+particular backup.  Merging of incrementals is done automatically, so you don't
+need to worry about whether certain files appear in the incremental or full
+backup.
 
 The usage is:
 
@@ -2240,48 +2145,47 @@ The usage is:
        -c level        compression level (default is 0, no compression)
        -e charset      charset for encoding filenames (default: utf8)
 
-The command-line files and directories are relative to the specified
-shareName.  The zip file is written to stdout. The -h, -n and -s
-options specify which dump is used to generate the zip archive.  The
--r and -p options can be used to relocate the paths in the zip archive
-so extracted files can be placed in a location different from their
-original location.
+The command-line files and directories are relative to the specified shareName.
+ The zip file is written to stdout. The -h, -n and -s options specify which
+dump is used to generate the zip archive.  The -r and -p options can be used to
+relocate the paths in the zip archive so extracted files can be placed in a
+location different from their original location.
 
 =item BackupPC_ls
 
-In V3, a full (or filled) backup tree contains all the files, albeit with "mangled"
-names, and the file contents are compressed.  Some users found it convenient to
-directly navigate a PC's backup tree to check for files.
+In V3, a full (or filled) backup tree contains all the files, albeit with
+"mangled" names, and the file contents are compressed.  Some users found it
+convenient to directly navigate a PC's backup tree to check for files.
 
-In V4 that is not possible, since only a single attrib file is stored per directory
-in the PC backup tree, so the directory contents aren't visible without looking in
-the attrib file.
+In V4 that is not possible, since only a single attrib file is stored per
+directory in the PC backup tree, so the directory contents aren't visible
+without looking in the attrib file.
 
-A new utility BackupPC_ls (like "ls") can be used to view PC backup trees.  It shows file digests,
-which can be pasted to BackupPC_zcat if you want to view the file contents.  The arguments
-are similar to BackupPC_zcat.  The usage is:
+A new utility BackupPC_ls (like "ls") can be used to view PC backup trees.  It
+shows file digests, which can be pasted to BackupPC_zcat if you want to view
+the file contents.  The arguments are similar to BackupPC_zcat.  The usage is:
 
     BackupPC_ls [-iR] [-h host] [-n bkupNum] [-s shareName] dirs/files...
 
-The -i option will show inodes (inode number and number of links).  The -R option recurses into
-directories.
+The -i option will show inodes (inode number and number of links).  The -R
+option recurses into directories.
 
-If you don't specify -h, -n and -s, then you can specify the real file system path instead.
-For example, the following three commands are equivalent:
+If you don't specify -h, -n and -s, then you can specify the real file system
+path instead. For example, the following three commands are equivalent:
 
     BackupPC_ls -h HOST -n 10 -s cDrive /home/craig/file
     BackupPC_ls /data/BackupPC/pc/HOST/10/fcDrive/fhome/fcraig/ffile
     BackupPC_ls /data/BackupPC/pc/HOST/10/cDrive/home/craig/file
 
-As you can see, the portion of the full path after the backup number can
-be either mangled or not.  Note that using the mangled form allows directory-name
+As you can see, the portion of the full path after the backup number can be
+either mangled or not.  Note that using the mangled form allows directory-name
 completion via the shell, since those directories actually exist.
 
-It would be great if someone would like to volunteer to add features to BackupPC_ls
-to make file and directory completion work with unmangled names via the shell.  In
-tcsh you can specify a completion program to run - BackupPC_ls could be given special
-arguments to spit out the potential (unmangled) completions.  I'm not sure how bash
-does this.
+It would be great if someone would like to volunteer to add features to
+BackupPC_ls to make file and directory completion work with unmangled names via
+the shell.  In tcsh you can specify a completion program to run - BackupPC_ls
+could be given special arguments to spit out the potential (unmangled)
+completions.  I'm not sure how bash does this.
 
 =back
 
@@ -2289,40 +2193,39 @@ Each of these programs reside in __INSTALLDIR__/bin.
 
 =head1 Archive functions
 
-BackupPC supports archiving to removable media. For users that require
-offsite backups, BackupPC can create archives that stream to tape
-devices, or create files of specified sizes to fit onto cd or dvd media.
+BackupPC supports archiving to removable media. For users that require offsite
+backups, BackupPC can create archives that stream to tape devices, or create
+files of specified sizes to fit onto cd or dvd media.
 
-Each archive type is specified by a BackupPC host with its XferMethod
-set to 'archive'. This allows for multiple configurations at sites where
-there might be a combination of tape and cd/dvd backups being made.
+Each archive type is specified by a BackupPC host with its XferMethod set to
+'archive'. This allows for multiple configurations at sites where there might
+be a combination of tape and cd/dvd backups being made.
 
-BackupPC provides a menu that allows one or more hosts to be archived.
-The most recent backup of each host is archived using BackupPC_tarCreate,
-and the output is optionally compressed and split into fixed-sized
-files (eg: 650MB).
+BackupPC provides a menu that allows one or more hosts to be archived. The most
+recent backup of each host is archived using BackupPC_tarCreate, and the output
+is optionally compressed and split into fixed-sized files (eg: 650MB).
 
 The archive for each host is done by default using
-__INSTALLDIR__/bin/BackupPC_archiveHost.  This script can be copied
-and customized as needed.
+__INSTALLDIR__/bin/BackupPC_archiveHost.  This script can be copied and
+customized as needed.
 
 =head2 Configuring an Archive Host
 
-To create an Archive Host, add it to the hosts file just as any other host
-and call it a name that best describes the type of archive, e.g. ArchiveDLT
+To create an Archive Host, add it to the hosts file just as any other host and
+call it a name that best describes the type of archive, e.g. ArchiveDLT
 
-To tell BackupPC that the Host is for Archives, create a config.pl file in
-the Archive Hosts's pc directory, adding the following line:
+To tell BackupPC that the Host is for Archives, create a config.pl file in the
+Archive Hosts's pc directory, adding the following line:
 
 $Conf{XferMethod} = 'archive';
 
 To further customise the archive's parameters you can add the changed
-parameters in the host's config.pl file. The parameters are explained in
-the config.pl file.  Parameters may be fixed or the user can be allowed
-to change them (eg: output device).
+parameters in the host's config.pl file. The parameters are explained in the
+config.pl file.  Parameters may be fixed or the user can be allowed to change
+them (eg: output device).
 
-The per-host archive command is $Conf{ArchiveClientCmd}.  By default
-this invokes
+The per-host archive command is $Conf{ArchiveClientCmd}.  By default this
+invokes
 
      __INSTALLDIR__/bin/BackupPC_archiveHost
 
@@ -2331,30 +2234,30 @@ which you can copy and customize as necessary.
 =head2 Starting an Archive
 
 In the web interface, click on the Archive Host you wish to use. You will see a
-list of previous archives and a summary on each. By clicking the "Start Archive"
-button you are presented with the list of hosts and the approximate backup size
-(note this is raw size, not projected compressed size) Select the hosts you wish
-to archive and press the "Archive Selected Hosts" button.
+list of previous archives and a summary on each. By clicking the "Start
+Archive" button you are presented with the list of hosts and the approximate
+backup size (note this is raw size, not projected compressed size) Select the
+hosts you wish to archive and press the "Archive Selected Hosts" button.
 
-The next screen allows you to adjust the parameters for this archive run.
-Press the "Start the Archive" to start archiving the selected hosts with the
+The next screen allows you to adjust the parameters for this archive run. Press
+the "Start the Archive" to start archiving the selected hosts with the
 parameters displayed.
 
 =head2 Starting an Archive from the command line
 
-The script BackupPC_archiveStart can be used to start an archive from
-the command line (or cron etc).  The usage is:
+The script BackupPC_archiveStart can be used to start an archive from the
+command line (or cron etc).  The usage is:
 
     BackupPC_archiveStart archiveHost userName hosts...
 
-This creates an archive of the most recent backup of each of
-the specified hosts.  The first two arguments are the archive
-host and the username making the request.
+This creates an archive of the most recent backup of each of the specified
+hosts.  The first two arguments are the archive host and the username making
+the request.
 
 =head1 Other Command Line Utilities
 
-These utilities are automatically run by BackupPC when needed.  You don't
-need to manually run these utilities.
+These utilities are automatically run by BackupPC when needed.  You don't need
+to manually run these utilities.
 
 =over
 
@@ -2367,7 +2270,8 @@ BackupPC_attribPrint prints the contents of an attrib file.  Usage:
 
 =item BackupPC_backupDelete
 
-BackupPC_backupDelete deletes an entire backup, or a directory path within a backup.  Usage:
+BackupPC_backupDelete deletes an entire backup, or a directory path within a
+backup.  Usage:
 
     BackupPC_backupDelete -h host -n num [-p] [-l] [-r] [-s shareName [dirs...]]
     Options:
@@ -2383,8 +2287,9 @@ BackupPC_backupDelete deletes an entire backup, or a directory path within a bac
 
 =item BackupPC_backupDuplicate
 
-BackupPC_backupDuplicate duplicates the last backup, which is used to create a filled backup
-copy, and also to convert a V3 backup to a new V4 starting point.  Usage:
+BackupPC_backupDuplicate duplicates the last backup, which is used to create a
+filled backup copy, and also to convert a V3 backup to a new V4 starting point.
+ Usage:
 
     BackupPC_backupDuplicate -h host [-p]
     Options:
@@ -2393,8 +2298,8 @@ copy, and also to convert a V3 backup to a new V4 starting point.  Usage:
 
 =item BackupPC_fixupBackupSummary
 
-BackupPC_fixupBackupSummary is used to re-create the backups file for all the hosts if it
-is damaged or deleted.  Usage:
+BackupPC_fixupBackupSummary is used to re-create the backups file for all the
+hosts if it is damaged or deleted.  Usage:
 
     BackupPC_fixupBackupSummary [-l]
     Options:
@@ -2403,8 +2308,9 @@ is damaged or deleted.  Usage:
 
 =item BackupPC_fsck
 
-BackupPC_fsck can only be run manually, and only while BackupPC isn't running.  It updates
-the host reference counts, the overall pool reference counts and stats.  Usage:
+BackupPC_fsck can only be run manually, and only while BackupPC isn't running.
+It updates the host reference counts, the overall pool reference counts and
+stats.  Usage:
 
     BackupPC_fsck [options]
     Options:
@@ -2414,14 +2320,14 @@ the host reference counts, the overall pool reference counts and stats.  Usage:
 
 =item BackupPC_migrateV3toV4
 
-If you upgraded an existing 3.x installation, BackupPC 4.x is backward compatible with 3.x backups:
-it can browse, view and restore files.  However, the existing 3.x backups will still use hardlinks
-for storage, and until those 3.x backups eventually expire, hardlinks will still be used for 3.x
-backups.
+If you upgraded an existing 3.x installation, BackupPC 4.x is backward
+compatible with 3.x backups: it can browse, view and restore files.  However,
+the existing 3.x backups will still use hardlinks for storage, and until those
+3.x backups eventually expire, hardlinks will still be used for 3.x backups.
 
-BackupPC_migrateV3toV4 is an optional utility that can migrate existing 3.x backups to 4.x stoage
-format, eliminating hardlinks.  This allows you to eliminate the old V3 pool and you can then
-set $Conf{PoolV3Enabled} to 0.
+BackupPC_migrateV3toV4 is an optional utility that can migrate existing 3.x
+backups to 4.x stoage format, eliminating hardlinks.  This allows you to
+eliminate the old V3 pool and you can then set $Conf{PoolV3Enabled} to 0.
 
     BackupPC_migrateV3toV4 -a [-m] [-p] [-v]
     BackupPC_migrateV3toV4 -h host [-n V3backupNum] [-m] [-p] [-v]
@@ -2438,9 +2344,9 @@ The BackupPC server should not be running when you run BackupPC_migrateV3toV4.
 It will check and exit if the BackupPC server is running.
 
 If you want to test BackupPC_migrateV3toV4, a cautious approach is to make
-backup copies of the V3 backups, allowing you to restore them if there is
-any issue.  For example, if exampleHost has three 3.x backups numbered 5,
-6, 7, you can use cp -prl (preserving hardlinks) to make copies:
+backup copies of the V3 backups, allowing you to restore them if there is any
+issue.  For example, if exampleHost has three 3.x backups numbered 5, 6, 7, you
+can use cp -prl (preserving hardlinks) to make copies:
 
     cd /data/BackupPC/pc/exampleHost
     mv 5 5.orig ; cp -prl 5.orig 5
@@ -2461,39 +2367,39 @@ If you want to put things back the way they were:
     # only do "cp backups.save backups" if you are sure no
     # new backups have been done
 
-Two important things to note with BackupPC_migrateV3toV4.  First, V4
-storage does use more filesystem inodes than V3 (that's the small cost
-of getting rid of hardlinks).  In particular, each directory in a backup
-tree uses two inodes in V4 (one for the directory, and one for the (empty)
-attrib file), and only one inode in V3 (one for the directory, and the
-attrib and all other files are hardlinked to the pool).  So before you run
-BackupPC_migrateV3toV4, make sure you have enough inodes in __TOPDIR__;
-use df -i to make sure you are under 45% inode usage.
+Two important things to note with BackupPC_migrateV3toV4.  First, V4 storage
+does use more filesystem inodes than V3 (that's the small cost of getting rid
+of hardlinks).  In particular, each directory in a backup tree uses two inodes
+in V4 (one for the directory, and one for the (empty) attrib file), and only
+one inode in V3 (one for the directory, and the attrib and all other files are
+hardlinked to the pool).  So before you run BackupPC_migrateV3toV4, make sure
+you have enough inodes in __TOPDIR__; use df -i to make sure you are under 45%
+inode usage.
 
-Secondly, if you run BackupPC_migrateV3toV4 on all your backups, the
-old V3 pool should be empty, except for old-style attrib files, which
-should all have only one link since no backups should reference them any
-longer.  Before you turn off the V3 pool by setting $Conf{PoolV3Enabled}
-to 0, make sure BackupPC_nightly has run enough times (specifically,
-$Conf{PoolSizeNightlyUpdatePeriod} times) so that the V3 pool can be
-emptied.  You could do this manually, but only if you are very careful
-to check that the remaining files only have one link.
+Secondly, if you run BackupPC_migrateV3toV4 on all your backups, the old V3
+pool should be empty, except for old-style attrib files, which should all have
+only one link since no backups should reference them any longer.  Before you
+turn off the V3 pool by setting $Conf{PoolV3Enabled} to 0, make sure
+BackupPC_nightly has run enough times (specifically,
+$Conf{PoolSizeNightlyUpdatePeriod} times) so that the V3 pool can be emptied.
+You could do this manually, but only if you are very careful to check that the
+remaining files only have one link.
 
 =item BackupPC_poolCntPrint
 
-BackupPC_poolCntPrint is used to print reference count information, either per-backup,
-per-host or for the entire pool depending on the file path you use.
+BackupPC_poolCntPrint is used to print reference count information, either
+per-backup, per-host or for the entire pool depending on the file path you use.
 
-If you provide a hex md5 digest, the entire pool count for that digest is printed.
-Usage:
+If you provide a hex md5 digest, the entire pool count for that digest is
+printed. Usage:
 
     BackupPC_poolCntPrint [poolCntFilePath|hexDigest]...
 
 =item BackupPC_refCountUpdate
 
-BackupPC_refCountUpdate is used to either update the per-backup and
-per-host reference counts, or the system-wide reference counts. It
-is used by BackupPC_dump, BackupPC_nightly, BackupPC_backupDelete,
+BackupPC_refCountUpdate is used to either update the per-backup and per-host
+reference counts, or the system-wide reference counts. It is used by
+BackupPC_dump, BackupPC_nightly, BackupPC_backupDelete,
 BackupPC_backupDuplicate and BackupPC_fsck.  Usage:
 
     BackupPC_refCountUpdate -h HOST [-c] [-f] [-F] [-o N] [-p] [-v]
@@ -2534,55 +2440,49 @@ BackupPC_backupDuplicate and BackupPC_fsck.  Usage:
 
 =head2 Configuration and Host Editor
 
-The CGI interface has a complete configuration and host editor.
-Only the administrator can edit the main configuration settings
-and hosts.  The edit links are in the left navigation bar.
+The CGI interface has a complete configuration and host editor. Only the
+administrator can edit the main configuration settings and hosts.  The edit
+links are in the left navigation bar.
 
-When changes are made to any parameter a "Save" button appears
-at the top of the page.  If you are editing a text box you will
-need to click outside of the text box to make the Save button
-appear.  If you don't select Save then the changes won't be saved.
+When changes are made to any parameter a "Save" button appears at the top of
+the page.  If you are editing a text box you will need to click outside of the
+text box to make the Save button appear.  If you don't select Save then the
+changes won't be saved.
 
-The host-specific configuration can be edited from the host
-summary page using the link in the left navigation bar.
-The administrator can edit any of the host-specific
-configuration settings.
+The host-specific configuration can be edited from the host summary page using
+the link in the left navigation bar. The administrator can edit any of the
+host-specific configuration settings.
 
-When editing the host-specific configuration, each parameter has
-an "override" setting that denotes the value is host-specific,
-meaning that it overrides the setting in the main configuration.
-If you deselect "override" then the setting is removed from
-the host-specific configuration, and the main configuration
+When editing the host-specific configuration, each parameter has an "override"
+setting that denotes the value is host-specific, meaning that it overrides the
+setting in the main configuration. If you deselect "override" then the setting
+is removed from the host-specific configuration, and the main configuration
 file is displayed.
 
-User's can edit their host-specific configuration if enabled
-via $Conf{CgiUserConfigEditEnable}.  The specific subset
-of configuration settings that a user can edit is specified
-with $Conf{CgiUserConfigEdit}.  It is recommended to make this
-list short as possible (you probably don't want your users saving
-dozens of backups) and it is essential that they can't edit any
-of the Cmd configuration settings, otherwise they can specify
-an arbitrary command that will be executed as the BackupPC
-user.
+User's can edit their host-specific configuration if enabled via
+$Conf{CgiUserConfigEditEnable}.  The specific subset of configuration settings
+that a user can edit is specified with $Conf{CgiUserConfigEdit}.  It is
+recommended to make this list short as possible (you probably don't want your
+users saving dozens of backups) and it is essential that they can't edit any of
+the Cmd configuration settings, otherwise they can specify an arbitrary command
+that will be executed as the BackupPC user.
 
 =head2 Metrics
 
-BackupPC supports a metrics endpoint that expose common information
-in a digest format. Allowed metrics formats are C<json> (default),
-C<prometheus> and C<rss>. Format should be specified using C<format>
-query parameter, a URL similar to this will provide metrics
-information:
+BackupPC supports a metrics endpoint that expose common information in a digest
+format. Allowed metrics formats are C<json> (default), C<prometheus> and
+C<rss>. Format should be specified using C<format> query parameter, a URL
+similar to this will provide metrics information:
 
     http://localhost/cgi-bin/BackupPC/BackupPC_Admin?action=metrics
     http://localhost/cgi-bin/BackupPC/BackupPC_Admin?action=metrics&format=json
     http://localhost/cgi-bin/BackupPC/BackupPC_Admin?action=metrics&format=prometheus
     http://localhost/cgi-bin/BackupPC/BackupPC_Admin?action=metrics&format=rss
 
-JSON format requires the JSON::XS module to be installed.
-RSS format requires the XML::RSS module to be installed.
+JSON format requires the JSON::XS module to be installed. RSS format requires
+the XML::RSS module to be installed.
 
-This feature is experimental. The information included will
-probably change.
+This feature is experimental. The information included will probably change.
 
 =over
 
@@ -2639,18 +2539,16 @@ probably change.
 
 =head2 RSS
 
-The RSS feed has been merged in the metrics endpoint (see section above). Please
-use the metrics endpoint to access the RSS feed, as the old endpoint will be
-deprecated.
+The RSS feed has been merged in the metrics endpoint (see section above).
+Please use the metrics endpoint to access the RSS feed, as the old endpoint
+will be deprecated.
 
-BackupPC supports a very basic RSS feed.  Provided you have the
-XML::RSS perl module installed, a URL similar to this will
-provide RSS information:
+BackupPC supports a very basic RSS feed.  Provided you have the XML::RSS perl
+module installed, a URL similar to this will provide RSS information:
 
     http://localhost/cgi-bin/BackupPC/BackupPC_Admin?action=rss
 
-This feature is experimental.  The information included will
-probably change.
+This feature is experimental.  The information included will probably change.
 
 =head1 BackupPC Design
 
@@ -2660,109 +2558,104 @@ probably change.
 
 =item Pooling common files
 
-To see if a file is already in the pool, an MD5 digest of the file
-contents is used.  This can't guarantee a file is identical: it
-just reduces the search to often a single file or handful of files.
+To see if a file is already in the pool, an MD5 digest of the file contents is
+used.  This can't guarantee a file is identical: it just reduces the search to
+often a single file or handful of files.
 
-Depending on the Xfer method and settings, a complete file comparison
-is done to verify if two files are really the same.
+Depending on the Xfer method and settings, a complete file comparison is done
+to verify if two files are really the same.
 
-Prior to V4, identical files on multiples backups are represented
-by hard links.  Hardlinks are used so that identical files all refer
-to the same physical file on the server's disk. Also, hard links
-maintain reference counts so that BackupPC knows when to delete
-unused files from the pool.
+Prior to V4, identical files on multiples backups are represented by hard
+links.  Hardlinks are used so that identical files all refer to the same
+physical file on the server's disk. Also, hard links maintain reference counts
+so that BackupPC knows when to delete unused files from the pool.
 
 In V4+, hardlinks are not used and reference counting is done at the
-application level.  It is done in a batch manner, which simplifies
-the implementation.
+application level.  It is done in a batch manner, which simplifies the
+implementation.
 
-For the computer-science majors among you, you can think of the pooling
-system used by BackupPC as just a chained hash table stored on a (big)
-file system.
+For the computer-science majors among you, you can think of the pooling system
+used by BackupPC as just a chained hash table stored on a (big) file system.
 
 =item The hashing function
 
-In V4+, the file digest is the MD5 digest of the complete file.
-While MD5 collisions are now well known, and can be easily constructed,
-in real use collisions will be extremely unlikely.
+In V4+, the file digest is the MD5 digest of the complete file. While MD5
+collisions are now well known, and can be easily constructed, in real use
+collisions will be extremely unlikely.
 
-Prior to V4, just a portion of all but the smallest files was used
-for the digest.  That decision was made long ago when CPUs were a
-lot slower.  For files less than 256K, the digest is the MD5 digest
-of the file size and the full file.  For files up to 1MB, the first
-and last 128K of the file, and for over 1MB, the first and eighth
-128K chunks are used, together with the file size.
+Prior to V4, just a portion of all but the smallest files was used for the
+digest.  That decision was made long ago when CPUs were a lot slower.  For
+files less than 256K, the digest is the MD5 digest of the file size and the
+full file.  For files up to 1MB, the first and last 128K of the file, and for
+over 1MB, the first and eighth 128K chunks are used, together with the file
+size.
 
 =item Compression
 
-BackupPC supports compression. It uses the deflate and inflate methods
-in the Compress::Zlib module, which is based on the zlib compression
-library (see L<http://www.gzip.org/zlib/>).
+BackupPC supports compression. It uses the deflate and inflate methods in the
+Compress::Zlib module, which is based on the zlib compression library (see
+L<http://www.gzip.org/zlib/>).
 
-The $Conf{CompressLevel} setting specifies the compression level to use.
-Zero (0) means no compression. Compression levels can be from 1 (least
-cpu time, slightly worse compression) to 9 (most cpu time, slightly
-better compression). The recommended value is 3. Changing it to 5, for
-example, will take maybe 20% more cpu time and will get another 2-3%
-additional compression.  Diminishing returns set in above 5.  See the zlib
-documentation for more information about compression levels.
+The $Conf{CompressLevel} setting specifies the compression level to use. Zero
+(0) means no compression. Compression levels can be from 1 (least cpu time,
+slightly worse compression) to 9 (most cpu time, slightly better compression).
+The recommended value is 3. Changing it to 5, for example, will take maybe 20%
+more cpu time and will get another 2-3% additional compression.  Diminishing
+returns set in above 5.  See the zlib documentation for more information about
+compression levels.
 
-BackupPC implements compression with minimal CPU load. Rather than
-compressing every incoming backup file and then trying to match it
-against the pool, BackupPC computes the MD5 digest based on the
-uncompressed file, and matches against the candidate pool files by
-comparing each uncompressed pool file against the incoming backup file.
-Since inflating a file takes roughly a factor of 10 less CPU time than
-deflating there is a big saving in CPU time.
+BackupPC implements compression with minimal CPU load. Rather than compressing
+every incoming backup file and then trying to match it against the pool,
+BackupPC computes the MD5 digest based on the uncompressed file, and matches
+against the candidate pool files by comparing each uncompressed pool file
+against the incoming backup file. Since inflating a file takes roughly a factor
+of 10 less CPU time than deflating there is a big saving in CPU time.
 
-The combination of pooling common files and compression can yield
-a factor of 8 or more overall saving in backup storage.
+The combination of pooling common files and compression can yield a factor of 8
+or more overall saving in backup storage.
 
-Note that you should not turn compression on and off are you have
-started running BackupPC.  It will result in double the storage needs,
-since all the files will be stored in both the compressed and uncompressed
-pools.
+Note that you should not turn compression on and off are you have started
+running BackupPC.  It will result in double the storage needs, since all the
+files will be stored in both the compressed and uncompressed pools.
 
 =back
 
 =head2 BackupPC operation
 
-BackupPC reads the configuration information from
-__CONFDIR__/config.pl. It then runs and manages all the backup
-activity. It maintains queues of pending backup requests, user backup
-requests and administrative commands. Based on the configuration various
-requests will be executed simultaneously.
+BackupPC reads the configuration information from __CONFDIR__/config.pl. It
+then runs and manages all the backup activity. It maintains queues of pending
+backup requests, user backup requests and administrative commands. Based on the
+configuration various requests will be executed simultaneously.
 
-As specified by $Conf{WakeupSchedule}, BackupPC wakes up periodically
-to queue backups on all the PCs.  This is a four step process:
+As specified by $Conf{WakeupSchedule}, BackupPC wakes up periodically to queue
+backups on all the PCs.  This is a four step process:
 
 =over 4
 
 =item 1
 
-For each host and DHCP address backup requests are queued on the
-background command queue.
+For each host and DHCP address backup requests are queued on the background
+command queue.
 
 =item 2
 
-For each PC, BackupPC_dump is forked. Several of these may be run in
-parallel, based on the configuration. First a ping is done to see if
-the machine is alive. If this is a DHCP address, nmblookup is run to
-get the netbios name, which is used as the hostname. If DNS lookup
-fails, $Conf{NmbLookupFindHostCmd} is run to find the IP address from
-the hostname.  The file __TOPDIR__/pc/$host/backups is read to decide
-whether a full or incremental backup needs to be run. If no backup is
-scheduled, or the ping to $host fails, then BackupPC_dump exits.
+For each PC, BackupPC_dump is forked. Several of these may be run in parallel,
+based on the configuration. First a ping is done to see if the machine is
+alive. If this is a DHCP address, nmblookup is run to get the netbios name,
+which is used as the hostname. If DNS lookup fails, $Conf{NmbLookupFindHostCmd}
+is run to find the IP address from the hostname.  The file
+__TOPDIR__/pc/$host/backups is read to decide whether a full or incremental
+backup needs to be run. If no backup is scheduled, or the ping to $host fails,
+then BackupPC_dump exits.
 
-The backup is done using the specified XferMethod.  Either samba's smbclient
-or tar over ssh/rsh/nfs piped into BackupPC_tarExtract, or rsync over ssh/rsh
-is run, or rsyncd is connected to, with the incoming data
-extracted to __TOPDIR__/pc/$host/new.  The XferMethod output is put
-into __TOPDIR__/pc/$host/XferLOG.
+The backup is done using the specified XferMethod.  Either samba's smbclient or
+tar over ssh/rsh/nfs piped into BackupPC_tarExtract, or rsync over ssh/rsh is
+run, or rsyncd is connected to, with the incoming data extracted to
+__TOPDIR__/pc/$host/new.  The XferMethod output is put into
+__TOPDIR__/pc/$host/XferLOG.
 
-The letter in the XferLOG file shows the type of object, similar to the
-first letter of the modes displayed by ls -l:
+The letter in the XferLOG file shows the type of object, similar to the first
+letter of the modes displayed by ls -l:
 
     d -> directory
     l -> symbolic link
@@ -2785,50 +2678,48 @@ found a match in the pool
 
 =item same
 
-file is identical to previous backup (contents were
-checksummed and verified during full dump).
+file is identical to previous backup (contents were checksummed and verified
+during full dump).
 
 =item skip
 
-file skipped in incremental because attributes are the
-same (only displayed if $Conf{XferLogLevel} >= 2).
+file skipped in incremental because attributes are the same (only displayed if
+$Conf{XferLogLevel} >= 2).
 
 =back
 
-As BackupPC_tarExtract extracts the files from smbclient or tar, or as
-rsync or ftp runs, it checks each file in the backup to see if it is
-identical to an existing file from any previous backup of any PC. It
-does this without needed to write the file to disk. If the file matches
-an existing file, a hardlink is created to the existing file in the
-pool. If the file does not match any existing files, the file is written
-to disk and inserted into the pool.
+As BackupPC_tarExtract extracts the files from smbclient or tar, or as rsync or
+ftp runs, it checks each file in the backup to see if it is identical to an
+existing file from any previous backup of any PC. It does this without needed
+to write the file to disk. If the file matches an existing file, a hardlink is
+created to the existing file in the pool. If the file does not match any
+existing files, the file is written to disk and inserted into the pool.
 
-BackupPC_tarExtract and rsync can handle arbitrarily large files
-and multiple candidate matching files without needing to write the
-file to disk in the case of a match.  This significantly reduces
-disk writes (and also reads, since the pool file comparison is done
-disk to memory, rather than disk to disk).
+BackupPC_tarExtract and rsync can handle arbitrarily large files and multiple
+candidate matching files without needing to write the file to disk in the case
+of a match.  This significantly reduces disk writes (and also reads, since the
+pool file comparison is done disk to memory, rather than disk to disk).
 
-Based on the configuration settings, BackupPC_dump checks each
-old backup to see if any should be removed.
+Based on the configuration settings, BackupPC_dump checks each old backup to
+see if any should be removed.
 
 =item 3
 
 Once each night, BackupPC_nightly is run to complete some additional
-administrative tasks, such as cleaning the pool.  This involves
-removing any files in the pool that only have a single hard link
-(meaning no backups are using that file).
+administrative tasks, such as cleaning the pool.  This involves removing any
+files in the pool that only have a single hard link (meaning no backups are
+using that file).
 
 If BackupPC_nightly takes too long to run, the settings
-$Conf{MaxBackupPCNightlyJobs} and $Conf{BackupPCNightlyPeriod} can
-be used to run several BackupPC_nightly processes in parallel, and
-to split its job over several nights.
+$Conf{MaxBackupPCNightlyJobs} and $Conf{BackupPCNightlyPeriod} can be used to
+run several BackupPC_nightly processes in parallel, and to split its job over
+several nights.
 
 =back
 
-BackupPC also listens for TCP connections on $Conf{ServerPort}, which
-is used by the CGI script BackupPC_Admin for status reporting and
-user-initiated backup or backup cancel requests.
+BackupPC also listens for TCP connections on $Conf{ServerPort}, which is used
+by the CGI script BackupPC_Admin for status reporting and user-initiated backup
+or backup cancel requests.
 
 =head2 Storage layout
 
@@ -2838,9 +2729,8 @@ BackupPC resides in several directories:
 
 =item __INSTALLDIR__
 
-Perl scripts comprising BackupPC reside in __INSTALLDIR__/bin,
-libraries are in __INSTALLDIR__/lib and documentation
-is in __INSTALLDIR__/doc.
+Perl scripts comprising BackupPC reside in __INSTALLDIR__/bin, libraries are in
+__INSTALLDIR__/lib and documentation is in __INSTALLDIR__/doc.
 
 =item __CGIDIR__
 
@@ -2848,8 +2738,8 @@ The CGI script BackupPC_Admin resides in this cgi binary directory.
 
 =item __CONFDIR__
 
-All the configuration information resides below __CONFDIR__.
-This directory contains:
+All the configuration information resides below __CONFDIR__. This directory
+contains:
 
 The directory __CONFDIR__ contains:
 
@@ -2865,9 +2755,9 @@ Hosts file, which lists all the PCs to backup.
 
 =item pc
 
-The directory __CONFDIR__/pc contains per-client configuration files
-that override settings in the main configuration file.  Each file
-is named __CONFDIR__/pc/HOST.pl, where HOST is the hostname.
+The directory __CONFDIR__/pc contains per-client configuration files that
+override settings in the main configuration file.  Each file is named
+__CONFDIR__/pc/HOST.pl, where HOST is the hostname.
 
 In pre-FHS versions of BackupPC these files were located in
 __TOPDIR__/pc/HOST/config.pl.
@@ -2876,8 +2766,8 @@ __TOPDIR__/pc/HOST/config.pl.
 
 =item __LOGDIR__
 
-The directory __LOGDIR__ (__TOPDIR__/log on pre-FHS versions
-of BackupPC) contains:
+The directory __LOGDIR__ (__TOPDIR__/log on pre-FHS versions of BackupPC)
+contains:
 
 =over 4
 
@@ -2887,26 +2777,26 @@ Current (today's) log file output from BackupPC.
 
 =item LOG.0 or LOG.0.z
 
-Yesterday's log file output.  Log files are aged daily and compressed
-(if compression is enabled), and old LOG files are deleted.
+Yesterday's log file output.  Log files are aged daily and compressed (if
+compression is enabled), and old LOG files are deleted.
 
 =item status.pl
 
-A summary of BackupPC's status written periodically by BackupPC so
-that certain state information can be maintained if BackupPC is
-restarted.  Should not be edited.
+A summary of BackupPC's status written periodically by BackupPC so that certain
+state information can be maintained if BackupPC is restarted.  Should not be
+edited.
 
 =item UserEmailInfo.pl
 
-A summary of what email was last sent to each user, and when the
-last email was sent.  Should not be edited.
+A summary of what email was last sent to each user, and when the last email was
+sent.  Should not be edited.
 
 =back
 
 =item __RUNDIR__
 
-The directory __RUNDIR__ (__TOPDIR__/log on pre-FHS versions
-of BackupPC) contains:
+The directory __RUNDIR__ (__TOPDIR__/log on pre-FHS versions of BackupPC)
+contains:
 
 =over 4
 
@@ -2922,8 +2812,8 @@ A unix domain socket for communicating to the BackupPC server.
 
 =item __TOPDIR__
 
-All of BackupPC's data (PC backup images, logs, configuration information)
-is stored below this directory.
+All of BackupPC's data (PC backup images, logs, configuration information) is
+stored below this directory.
 
 Below __TOPDIR__ are several directories:
 
@@ -2931,70 +2821,70 @@ Below __TOPDIR__ are several directories:
 
 =item __TOPDIR__/pool
 
-All uncompressed files from PC backups are stored below __TOPDIR__/pool.
-Each file's name is based on the MD5 hex digest of the file contents.
+All uncompressed files from PC backups are stored below __TOPDIR__/pool. Each
+file's name is based on the MD5 hex digest of the file contents.
 
-For V4+, the digest is the MD5 digest of the full file contents (the length
-is not used).  For V4+ the pool files are stored in a 2 level tree, using
-7 bits from the top of the first two bytes of the digest.  So there are 128
+For V4+, the digest is the MD5 digest of the full file contents (the length is
+not used).  For V4+ the pool files are stored in a 2 level tree, using 7 bits
+from the top of the first two bytes of the digest.  So there are 128
 directories at each level, numbered evenly in hex from 0x00, 0x02, to 0xfe.
 
 For example, if a file has an MD5 digest of 123456789abcdef0123456789abcdef0,
-the uncompressed file is stored in __TOPDIR__/pool/12/34/123456789abcdef0123456789abcdef0.
+the uncompressed file is stored in
+__TOPDIR__/pool/12/34/123456789abcdef0123456789abcdef0.
 
-Duplicates digest are represented with one (or more) hex byte extensions.
-So three colliding files would be stored as
+Duplicates digest are represented with one (or more) hex byte extensions. So
+three colliding files would be stored as
 
 	__TOPDIR__/pool/12/34/123456789abcdef0123456789abcdef0
 	__TOPDIR__/pool/12/34/123456789abcdef0123456789abcdef000
 	__TOPDIR__/pool/12/34/123456789abcdef0123456789abcdef001
 
-The rest of this section describes the old pool layout.  Note that both V3 and V4
-pools can exist together, since they use different names for their directory trees.
+The rest of this section describes the old pool layout.  Note that both V3 and
+V4 pools can exist together, since they use different names for their directory
+trees.
 
-As exampled earlier, prior to V4 the digest is computed as follows.
-For files less than 256K, the file length and the entire
-file is used. For files up to 1MB, the file length and the first and
-last 128K are used. Finally, for files longer than 1MB, the file length,
-and the first and eighth 128K chunks for the file are used.
+As exampled earlier, prior to V4 the digest is computed as follows. For files
+less than 256K, the file length and the entire file is used. For files up to
+1MB, the file length and the first and last 128K are used. Finally, for files
+longer than 1MB, the file length, and the first and eighth 128K chunks for the
+file are used.
 
-Both BackupPC_dump (actually, BackupPC_tarExtract or rsync_bpc) are
-responsible for checking newly backed up files against the pool. For
-each file, the MD5 digest is used to generate a filename in the pool
-directory.
+Both BackupPC_dump (actually, BackupPC_tarExtract or rsync_bpc) are responsible
+for checking newly backed up files against the pool. For each file, the MD5
+digest is used to generate a filename in the pool directory.
 
-If the file exists in the pool, the contents are compared.
-If there is no match, additional files in the chain are checked (if any).
-(Actually, multiple candidate files are compared in parallel.)
+If the file exists in the pool, the contents are compared. If there is no
+match, additional files in the chain are checked (if any). (Actually, multiple
+candidate files are compared in parallel.)
 
-If $Conf{PoolV3Enabled} is set, then the V3 pool is checked
-if there are no matches in the V4 pool.  If a V3 file matches, it is
-simply moved (renamed) the the V4 pool with it's new filename based on
-the V4 digest.  That still allows the V3 backups to be browsed etc, since
-those backups are still based on hardlinks.
+If $Conf{PoolV3Enabled} is set, then the V3 pool is checked if there are no
+matches in the V4 pool.  If a V3 file matches, it is simply moved (renamed) the
+the V4 pool with it's new filename based on the V4 digest.  That still allows
+the V3 backups to be browsed etc, since those backups are still based on
+hardlinks.
 
 If the file contents exactly match, a reference count is incremented.
 Otherwise, the file is added to the pool by using an atomic link operation,
 followed by unlinking the temporary file.
 
-One other issue: zero length files are not pooled, since there are a lot
-of these files and on most file systems it doesn't save any disk space
-to turn these files into hard links.
+One other issue: zero length files are not pooled, since there are a lot of
+these files and on most file systems it doesn't save any disk space to turn
+these files into hard links.
 
-Prior to V4, each pool file is stored in a subdirectory X/Y/Z, where X,
-Y, Z are the first 3 hex digits of the MD5 digest.
+Prior to V4, each pool file is stored in a subdirectory X/Y/Z, where X, Y, Z
+are the first 3 hex digits of the MD5 digest.
 
 For example, if a file has an MD5 digest of 123456789abcdef0123456789abcdef0,
 the file is stored in __TOPDIR__/pool/1/2/3/123456789abcdef0123456789abcdef0.
 
 The MD5 digest might not be unique (especially since not all the file's
-contents are used for files bigger than 256K). Different files that have
-the same MD5 digest are stored with a trailing suffix "_n" where n is
-an incrementing number starting at 0. So, for example, if two additional
-files were identical to the first, except the last byte was different,
-and assuming the file was larger than 1MB (so the MD5 digests are the
-same but the files are actually different), the three files would be
-stored as:
+contents are used for files bigger than 256K). Different files that have the
+same MD5 digest are stored with a trailing suffix "_n" where n is an
+incrementing number starting at 0. So, for example, if two additional files
+were identical to the first, except the last byte was different, and assuming
+the file was larger than 1MB (so the MD5 digests are the same but the files are
+actually different), the three files would be stored as:
 
 	__TOPDIR__/pool/1/2/3/123456789abcdef0123456789abcdef0
 	__TOPDIR__/pool/1/2/3/123456789abcdef0123456789abcdef0_0
@@ -3002,16 +2892,14 @@ stored as:
 
 =item __TOPDIR__/cpool
 
-All compressed files from PC backups are stored below __TOPDIR__/cpool.
-Its layout is the same as __TOPDIR__/pool, and the hashing function
-is the same (and, importantly, based on the uncompressed file, not
-the compressed file).
+All compressed files from PC backups are stored below __TOPDIR__/cpool. Its
+layout is the same as __TOPDIR__/pool, and the hashing function is the same
+(and, importantly, based on the uncompressed file, not the compressed file).
 
 =item __TOPDIR__/pc/$host
 
-For each PC $host, all the backups for that PC are stored below
-the directory __TOPDIR__/pc/$host.  This directory contains the
-following files:
+For each PC $host, all the backups for that PC are stored below the directory
+__TOPDIR__/pc/$host.  This directory contains the following files:
 
 =over 4
 
@@ -3021,26 +2909,25 @@ Current log file for this PC from BackupPC_dump.
 
 =item LOG.MMYYYY or LOG.MMYYYY.z
 
-Last month's log file.  Log files are aged monthly and compressed
-(if compression is enabled), and old LOG files are deleted.
-In earlier versions of BackupPC these files used to have
-a suffix of 0, 1, ....
+Last month's log file.  Log files are aged monthly and compressed (if
+compression is enabled), and old LOG files are deleted. In earlier versions of
+BackupPC these files used to have a suffix of 0, 1, ....
 
 =item XferERR or XferERR.z
 
-Output from the transport program (ie: smbclient, tar, rsync or ftp)
-for the most recent failed backup.
+Output from the transport program (ie: smbclient, tar, rsync or ftp) for the
+most recent failed backup.
 
 =item XferLOG or XferLOG.z
 
-Output from the transport program (ie: smbclient, tar, rsync or ftp)
-for the current backup.
+Output from the transport program (ie: smbclient, tar, rsync or ftp) for the
+current backup.
 
 =item nnn (an integer)
 
-Backups are in directories numbered sequentially starting at 0.  Below
-each backup directory are the inodes (in nnn/inode) and the reference
-counts for this backup are in nnn/refCnt.
+Backups are in directories numbered sequentially starting at 0.  Below each
+backup directory are the inodes (in nnn/inode) and the reference counts for
+this backup are in nnn/refCnt.
 
 =item refCnt
 
@@ -3053,46 +2940,44 @@ corresponding to backup number nnn.
 
 =item RestoreInfo.nnn
 
-Information about restore request #nnn including who, what, when, and
-why. This file is in Data::Dumper format.  (Note that the restore
-numbers are not related to the backup number.)
+Information about restore request #nnn including who, what, when, and why. This
+file is in Data::Dumper format.  (Note that the restore numbers are not related
+to the backup number.)
 
 =item RestoreLOG.nnn.z
 
-Output from smbclient, tar or rsync during restore #nnn.  (Note that the restore
-numbers are not related to the backup number.)
+Output from smbclient, tar or rsync during restore #nnn.  (Note that the
+restore numbers are not related to the backup number.)
 
 =item ArchiveInfo.nnn
 
-Information about archive request #nnn including who, what, when, and
-why. This file is in Data::Dumper format.  (Note that the archive
-numbers are not related to the restore or backup number.)
+Information about archive request #nnn including who, what, when, and why. This
+file is in Data::Dumper format.  (Note that the archive numbers are not related
+to the restore or backup number.)
 
 =item ArchiveLOG.nnn.z
 
-Output from archive #nnn.  (Note that the archive numbers are not related
-to the backup or restore number.)
+Output from archive #nnn.  (Note that the archive numbers are not related to
+the backup or restore number.)
 
 =item config.pl
 
-Old location of optional configuration settings specific to this host.
-Settings in this file override the main configuration file.
-In new versions of BackupPC the per-host configuration files are
-stored in __CONFDIR__/pc/HOST.pl.
+Old location of optional configuration settings specific to this host. Settings
+in this file override the main configuration file. In new versions of BackupPC
+the per-host configuration files are stored in __CONFDIR__/pc/HOST.pl.
 
 =item backups
 
-A tab-delimited ascii table listing information about each successful
-backup, one per row.  The columns are:
+A tab-delimited ascii table listing information about each successful backup,
+one per row.  The columns are:
 
 =over 4
 
 =item num
 
-The backup number, an integer that starts at 0 and increments
-for each successive backup.  The corresponding backup is stored
-in the directory num (eg: if this field is 5, then the backup is
-stored in __TOPDIR__/pc/$host/5).
+The backup number, an integer that starts at 0 and increments for each
+successive backup.  The corresponding backup is stored in the directory num
+(eg: if this field is 5, then the backup is stored in __TOPDIR__/pc/$host/5).
 
 =item type
 
@@ -3116,23 +3001,20 @@ Total file size backed up (as reported by smbclient, tar, rsync or ftp).
 
 =item nFilesExist
 
-Number of files that were already in the pool
-(as determined by BackupPC_dump).
+Number of files that were already in the pool (as determined by BackupPC_dump).
 
 =item sizeExist
 
-Total size of files that were already in the pool
-(as determined by BackupPC_dump).
+Total size of files that were already in the pool (as determined by
+BackupPC_dump).
 
 =item nFilesNew
 
-Number of files that were not in the pool
-(as determined by BackupPC_dump).
+Number of files that were not in the pool (as determined by BackupPC_dump).
 
 =item sizeNew
 
-Total size of files that were not in the pool
-(as determined by BackupPC_dump).
+Total size of files that were not in the pool (as determined by BackupPC_dump).
 
 =item xferErrs
 
@@ -3152,34 +3034,32 @@ Number of errors from BackupPC_tarExtract.
 
 =item compress
 
-The compression level used on this backup.  Zero or empty means no
-compression.
+The compression level used on this backup.  Zero or empty means no compression.
 
 =item sizeExistComp
 
-Total compressed size of files that were already in the pool
-(as determined by BackupPC_dump).
+Total compressed size of files that were already in the pool (as determined by
+BackupPC_dump).
 
 =item sizeNewComp
 
-Total compressed size of files that were not in the pool
-(as determined by BackupPC_dump).
+Total compressed size of files that were not in the pool (as determined by
+BackupPC_dump).
 
 =item noFill
 
-Set if this backup has not been filled - it just includes the
-deltas from the next backup necessary to reconstruct this backup.
+Set if this backup has not been filled - it just includes the deltas from the
+next backup necessary to reconstruct this backup.
 
 =item fillFromNum
 
-If this backup was filled (ie: noFill is 0) then this is the
-number of the backup that it was filled from
+If this backup was filled (ie: noFill is 0) then this is the number of the
+backup that it was filled from
 
 =item mangle
 
-Set if this backup has mangled filenames and attributes.  Always
-true for backups in v1.4.0 and above.  False for all backups prior
-to v1.4.0.
+Set if this backup has mangled filenames and attributes.  Always true for
+backups in v1.4.0 and above.  False for all backups prior to v1.4.0.
 
 =item xferMethod
 
@@ -3187,9 +3067,9 @@ Set to the value of $Conf{XferMethod} when this dump was done.
 
 =item level
 
-The level of this dump.  A full dump is level 0.  Currently incrementals
-are 1.  In V4+ multi-level incrementals are no longer supported, so this
-is just a 0 or 1.
+The level of this dump.  A full dump is level 0.  Currently incrementals are 1.
+ In V4+ multi-level incrementals are no longer supported, so this is just a 0
+or 1.
 
 =item charset
 
@@ -3209,23 +3089,23 @@ If set this backup won't be deleted.
 
 =item share2path
 
-Saves the value of $Conf{ClientShareName2Path} via Data::Dumper (with some tabs,
-newlines and % characters replaced with %xx) so that the actual client path
-for each share can be displayed when browsing.
+Saves the value of $Conf{ClientShareName2Path} via Data::Dumper (with some
+tabs, newlines and % characters replaced with %xx) so that the actual client
+path for each share can be displayed when browsing.
 
 =back
 
 =item restores
 
-A tab-delimited ascii table listing information about each requested
-restore, one per row.  The columns are:
+A tab-delimited ascii table listing information about each requested restore,
+one per row.  The columns are:
 
 =over 4
 
 =item num
 
-Restore number (matches the suffix of the RestoreInfo.nnn and
-RestoreLOG.nnn.z file), unrelated to the backup number.
+Restore number (matches the suffix of the RestoreInfo.nnn and RestoreLOG.nnn.z
+file), unrelated to the backup number.
 
 =item startTime
 
@@ -3263,15 +3143,15 @@ Number of errors from smbclient, tar, rsync or ftp during restore.
 
 =item archives
 
-A tab-delimited ascii table listing information about each requested
-archive, one per row.  The columns are:
+A tab-delimited ascii table listing information about each requested archive,
+one per row.  The columns are:
 
 =over 4
 
 =item num
 
-Archive number (matches the suffix of the ArchiveInfo.nnn and
-ArchiveLOG.nnn.z file), unrelated to the backup or restore number.
+Archive number (matches the suffix of the ArchiveInfo.nnn and ArchiveLOG.nnn.z
+file), unrelated to the backup or restore number.
 
 =item startTime
 
@@ -3299,126 +3179,118 @@ Error message if archive failed.
 
 =head2 Compressed file format
 
-The compressed file format is as generated by Compress::Zlib::deflate
-with one minor, but important, tweak. Since Compress::Zlib::inflate
-fully inflates its argument in memory, it could take large amounts of
-memory if it was inflating a highly compressed file. For example, a
-200MB file of 0x0 bytes compresses to around 200K bytes. If
-Compress::Zlib::inflate was called with this single 200K buffer, it
-would need to allocate 200MB of memory to return the result.
+The compressed file format is as generated by Compress::Zlib::deflate with one
+minor, but important, tweak. Since Compress::Zlib::inflate fully inflates its
+argument in memory, it could take large amounts of memory if it was inflating a
+highly compressed file. For example, a 200MB file of 0x0 bytes compresses to
+around 200K bytes. If Compress::Zlib::inflate was called with this single 200K
+buffer, it would need to allocate 200MB of memory to return the result.
 
-BackupPC watches how efficiently a file is compressing. If a big file
-has very high compression (meaning it will use too much memory when it
-is inflated), BackupPC calls the flush() method, which gracefully
-completes the current compression.  BackupPC then starts another
-deflate and simply appends the output file.  So the BackupPC compressed
-file format is one or more concatenated deflations/flushes.  The specific
-ratios that BackupPC uses is that if a 6MB chunk compresses to less
-than 64K then a flush will be done.
+BackupPC watches how efficiently a file is compressing. If a big file has very
+high compression (meaning it will use too much memory when it is inflated),
+BackupPC calls the flush() method, which gracefully completes the current
+compression.  BackupPC then starts another deflate and simply appends the
+output file.  So the BackupPC compressed file format is one or more
+concatenated deflations/flushes.  The specific ratios that BackupPC uses is
+that if a 6MB chunk compresses to less than 64K then a flush will be done.
 
-Back to the example of the 200MB file of 0x0 bytes.  Adding flushes
-every 6MB adds only 200 or so bytes to the 200K output.  So the
-storage cost of flushing is negligible.
+Back to the example of the 200MB file of 0x0 bytes.  Adding flushes every 6MB
+adds only 200 or so bytes to the 200K output.  So the storage cost of flushing
+is negligible.
 
-To easily decompress a BackupPC compressed file, the script
-BackupPC_zcat can be found in __INSTALLDIR__/bin.  For each
-filename argument it inflates the file and writes it to stdout.
+To easily decompress a BackupPC compressed file, the script BackupPC_zcat can
+be found in __INSTALLDIR__/bin.  For each filename argument it inflates the
+file and writes it to stdout.
 
 =head2 Rsync checksum caching
 
-Rsync checksum caching is not implemented in V4. That's because a full
-backup with rsync in V4 uses client-side whole-file checksums during a full
-backup, meaning that the server doesn't need to send block-level digests on
-every full backup.
+Rsync checksum caching is not implemented in V4. That's because a full backup
+with rsync in V4 uses client-side whole-file checksums during a full backup,
+meaning that the server doesn't need to send block-level digests on every full
+backup.
 
 The rest of this section applies to V3.
 
-An incremental backup with rsync compares attributes on the client
-with the last full backup.  Any files with identical attributes
-are skipped.  In V3, a full backup with rsync sets the --ignore-times
-option, which causes every file to be examined independent of
-attributes.
+An incremental backup with rsync compares attributes on the client with the
+last full backup.  Any files with identical attributes are skipped.  In V3, a
+full backup with rsync sets the --ignore-times option, which causes every file
+to be examined independent of attributes.
 
-Each file is examined by generating block checksums (default 2K
-blocks) on the receiving side (that's the BackupPC side), sending
-those checksums to the client, where the remote rsync matches those
-checksums with the corresponding file.  The matching blocks and new
-data is sent back, allowing the client file to be reassembled.
-A checksum for the entire file is sent to as an extra check the
-the reconstructed file is correct.
+Each file is examined by generating block checksums (default 2K blocks) on the
+receiving side (that's the BackupPC side), sending those checksums to the
+client, where the remote rsync matches those checksums with the corresponding
+file.  The matching blocks and new data is sent back, allowing the client file
+to be reassembled. A checksum for the entire file is sent to as an extra check
+the the reconstructed file is correct.
 
-This results in significant disk IO and computation for BackupPC:
-every file in a full backup, or any file with non-matching attributes
-in an incremental backup, needs to be uncompressed, block checksums
-computed and sent.  Then the receiving side reassembles the file and
-has to verify the whole-file checksum.  Even if the file is identical,
-prior to 2.1.0, BackupPC had to read and uncompress the file twice,
-once to compute the block checksums and later to verify the whole-file
-checksum.
+This results in significant disk IO and computation for BackupPC: every file in
+a full backup, or any file with non-matching attributes in an incremental
+backup, needs to be uncompressed, block checksums computed and sent.  Then the
+receiving side reassembles the file and has to verify the whole-file checksum.
+Even if the file is identical, prior to 2.1.0, BackupPC had to read and
+uncompress the file twice, once to compute the block checksums and later to
+verify the whole-file checksum.
 
 =head2 Filename mangling
 
-Backup filenames are stored in "mangled" form. Each node of
-a path is preceded by "f" (mnemonic: file), and special characters
-(\n, \r, % and /) are URI-encoded as "%xx", where xx is the ascii
-character's hex value.  So c:/craig/example.txt is now stored as
-fc/fcraig/fexample.txt.
+Backup filenames are stored in "mangled" form. Each node of a path is preceded
+by "f" (mnemonic: file), and special characters (\n, \r, % and /) are
+URI-encoded as "%xx", where xx is the ascii character's hex value.  So
+c:/craig/example.txt is now stored as fc/fcraig/fexample.txt.
 
-This was done mainly so metadata could be stored alongside the backup
-files without name collisions. In particular, the attributes for the
-files in a directory are stored in a file called "attrib", and mangling
-avoids filename collisions (I discarded the idea of having a duplicate
-directory tree for every backup just to store the attributes). Other
-metadata (eg: rsync checksums) could be stored in filenames preceded
-by, eg, "c". There are two other benefits to mangling: the share name
-might contain "/" (eg: "/home/craig" for tar transport), and I wanted
-that represented as a single level in the storage tree.
+This was done mainly so metadata could be stored alongside the backup files
+without name collisions. In particular, the attributes for the files in a
+directory are stored in a file called "attrib", and mangling avoids filename
+collisions (I discarded the idea of having a duplicate directory tree for every
+backup just to store the attributes). Other metadata (eg: rsync checksums)
+could be stored in filenames preceded by, eg, "c". There are two other benefits
+to mangling: the share name might contain "/" (eg: "/home/craig" for tar
+transport), and I wanted that represented as a single level in the storage
+tree.
 
 The CGI script undoes the mangling, so it is invisible to the user.
 
 =head2 Special files
 
-Linux/unix file systems support several special file types: symbolic
-links, character and block device files, fifos (pipes) and unix-domain
-sockets. All except unix-domain sockets are supported by BackupPC
-(there's no point in backing up or restoring unix-domain sockets since
-they only have meaning after a process creates them). Symbolic links are
-stored as a plain file whose contents are the contents of the link (not
-the file it points to). This file is compressed and pooled like any
-normal file. Character and block device files are also stored as plain
-files, whose contents are two integers separated by a comma; the numbers
-are the major and minor device number. These files are compressed and
-pooled like any normal file. Fifo files are stored as empty plain files
-(which are not pooled since they have zero size). In all cases, the
+Linux/unix file systems support several special file types: symbolic links,
+character and block device files, fifos (pipes) and unix-domain sockets. All
+except unix-domain sockets are supported by BackupPC (there's no point in
+backing up or restoring unix-domain sockets since they only have meaning after
+a process creates them). Symbolic links are stored as a plain file whose
+contents are the contents of the link (not the file it points to). This file is
+compressed and pooled like any normal file. Character and block device files
+are also stored as plain files, whose contents are two integers separated by a
+comma; the numbers are the major and minor device number. These files are
+compressed and pooled like any normal file. Fifo files are stored as empty
+plain files (which are not pooled since they have zero size). In all cases, the
 original file type is stored in the attrib file so it can be correctly
 restored.
 
-Hardlinks are supported.  In V4, file metadata include an inode number
-and a link count.  Any file with more than one link points at the inode
-information stored below the backup directory in the inode directory.
-That directory contains a tree of up to 16K attrib files based on bits
-10-23 of the inode number.  In particular, the directory name uses bits
-17-23, and the attrib filename includes bits 10-16.  The key (index) in
-the attrib file is the hex inode number.  The original file metadata's
-link count might not be accurate; it's more a flag (>1) for when to look
-up the inode information.  The correct link count is stored in the inode.
+Hardlinks are supported.  In V4, file metadata include an inode number and a
+link count.  Any file with more than one link points at the inode information
+stored below the backup directory in the inode directory. That directory
+contains a tree of up to 16K attrib files based on bits 10-23 of the inode
+number.  In particular, the directory name uses bits 17-23, and the attrib
+filename includes bits 10-16.  The key (index) in the attrib file is the hex
+inode number.  The original file metadata's link count might not be accurate;
+it's more a flag (>1) for when to look up the inode information.  The correct
+link count is stored in the inode.
 
-In V3, hardlinks are stored in a similar manner to symlinks.  When GNU
-tar first encounters a file with more than one link (ie: hardlinks)
-it dumps it as a regular file.  When it sees the second and subsequent
-hardlinks to the same file, it dumps just the hardlink information.
-BackupPC correctly recognizes these hardlinks and stores them just like
-symlinks: a regular text file whose contents is the path of the file
-linked to.  The CGI script will download the original file when you
-click on a hardlink.
+In V3, hardlinks are stored in a similar manner to symlinks.  When GNU tar
+first encounters a file with more than one link (ie: hardlinks) it dumps it as
+a regular file.  When it sees the second and subsequent hardlinks to the same
+file, it dumps just the hardlink information. BackupPC correctly recognizes
+these hardlinks and stores them just like symlinks: a regular text file whose
+contents is the path of the file linked to.  The CGI script will download the
+original file when you click on a hardlink.
 
 Also, BackupPC_tarCreate has enough magic to re-create the hardlinks
-dynamically based on whether or not the original file and hardlinks
-are both included in the tar file.  For example, imagine a/b/x is a
-hardlink to a/c/y.  If you use BackupPC_tarCreate to restore directory
-a, then the tar file will include a/b/x as the original file and a/c/y
-will be a hardlink to a/b/x.  If, instead you restore a/c, then the
-tar file will include a/c/y as the original file, not a hardlink.
+dynamically based on whether or not the original file and hardlinks are both
+included in the tar file.  For example, imagine a/b/x is a hardlink to a/c/y.
+If you use BackupPC_tarCreate to restore directory a, then the tar file will
+include a/b/x as the original file and a/c/y will be a hardlink to a/b/x.  If,
+instead you restore a/c, then the tar file will include a/c/y as the original
+file, not a hardlink.
 
 =head2 Attribute file format
 
@@ -3426,9 +3298,9 @@ tar file will include a/c/y as the original file, not a hardlink.
 
 =item V4 attrib files
 
-The attribute file format is new in V4.  Every backup directory contains
-an attrib file, which is zero length and its name includes the MD5 pool
-digest, eg:
+The attribute file format is new in V4.  Every backup directory contains an
+attrib file, which is zero length and its name includes the MD5 pool digest,
+eg:
 
     attrib_33fe8f9ae2f5cedbea63b9d3ea767ac0
 
@@ -3436,17 +3308,17 @@ The digest is used to look up the contents in the V4 cpool, eg:
 
     __TOPDIR__/cpool/32/fe/33fe8f9ae2f5cedbea63b9d3ea767ac0
 
-For inode attrib files, bits 17-23 (XX in hex) of the inode number are used for the
-directory name, and the attrib filename includes bits 10-16 (YY in hex), so
+For inode attrib files, bits 17-23 (XX in hex) of the inode number are used for
+the directory name, and the attrib filename includes bits 10-16 (YY in hex), so
 relative to the backup directory:
 
     inode/XX/attribYY_33fe8f9ae2f5cedbea63b9d3ea767ac0
 
 An empty attrib file has the name "attrib_0" (or "attribYY_0" for inodes).
 
-The attrib file starts with a magic number, followed by the concatenation
-of the following information for each file (all integers are stored in
-perl's pack "w" format (variable length base 128)):
+The attrib file starts with a magic number, followed by the concatenation of
+the following information for each file (all integers are stored in perl's pack
+"w" format (variable length base 128)):
 
 =over 4
 
@@ -3460,8 +3332,8 @@ Count of extended attributes
 
 =item *
 
-The unix file type, mtime, mode, uid, gid, size, inode number, compress,
-number of links
+The unix file type, mtime, mode, uid, gid, size, inode number, compress, number
+of links
 
 =item *
 
@@ -3469,23 +3341,23 @@ MD5 digest length, followed by the digest contents
 
 =item *
 
-Each extended attribute (length of xattr name, length of xattr value, name, value)
+Each extended attribute (length of xattr name, length of xattr value, name,
+value)
 
 =back
 
 =item V3 attrib files
 
 The unix attributes for the contents of a directory (all the files and
-directories in that directory) are stored in a file called attrib.
-There is a single attrib file for each directory in a backup.
-For example, if c:/craig contains a single file c:/craig/example.txt,
-that file would be stored as fc/fcraig/fexample.txt and there would be an
-attribute file in fc/fcraig/attrib (and also fc/attrib and ./attrib).
-The file fc/fcraig/attrib would contain a single entry containing the
-attributes for fc/fcraig/fexample.txt.
+directories in that directory) are stored in a file called attrib. There is a
+single attrib file for each directory in a backup. For example, if c:/craig
+contains a single file c:/craig/example.txt, that file would be stored as
+fc/fcraig/fexample.txt and there would be an attribute file in fc/fcraig/attrib
+(and also fc/attrib and ./attrib). The file fc/fcraig/attrib would contain a
+single entry containing the attributes for fc/fcraig/fexample.txt.
 
-The attrib file starts with a magic number, followed by the
-concatenation of the following information for each file:
+The attrib file starts with a magic number, followed by the concatenation of
+the following information for each file:
 
 =over 4
 
@@ -3499,9 +3371,9 @@ Filename.
 
 =item *
 
-The unix file type, mode, uid, gid and file size divided by 4GB and
-file size modulo 4GB (type mode uid gid sizeDiv4GB sizeMod4GB),
-in perl's pack "w" format (variable length base 128).
+The unix file type, mode, uid, gid and file size divided by 4GB and file size
+modulo 4GB (type mode uid gid sizeDiv4GB sizeMod4GB), in perl's pack "w" format
+(variable length base 128).
 
 =item *
 
@@ -3509,89 +3381,96 @@ The unix mtime (unix seconds) in perl's pack "N" format (32 bit integer).
 
 =back
 
-The attrib file is also compressed if compression is enabled.
-See the lib/BackupPC/Attrib.pm module for full details.
+The attrib file is also compressed if compression is enabled. See the
+lib/BackupPC/Attrib.pm module for full details.
 
-Attribute files are pooled just like normal backup files.  This saves
-space if all the files in a directory have the same attributes across
-multiple backups, which is common.
+Attribute files are pooled just like normal backup files.  This saves space if
+all the files in a directory have the same attributes across multiple backups,
+which is common.
 
 =back
 
 =head2 Optimizations
 
-BackupPC doesn't care about the access time of files in the pool
-since it saves attribute metadata separate from the files.  Since
-BackupPC mostly does reads from disk, maintaining the access time of
-files generates a lot of unnecessary disk writes.  So, provided
-BackupPC has a dedicated data disk, you should consider mounting
-BackupPC's data directory with the noatime (or, with Linux kernels
->=2.6.20, relatime) attribute (see mount(1)).
+BackupPC doesn't care about the access time of files in the pool since it saves
+attribute metadata separate from the files.  Since BackupPC mostly does reads
+from disk, maintaining the access time of files generates a lot of unnecessary
+disk writes.  So, provided BackupPC has a dedicated data disk, you should
+consider mounting BackupPC's data directory with the noatime (or, with Linux
+kernels >=2.6.20, relatime) attribute (see mount(1)).
 
 =head2 Some Limitations
 
 =head3 Non-unix file attributes not backed up
 
-smbclient doesn't extract the WinXX ACLs, so file attributes other than
-the equivalent (as provided by smbclient) unix attributes are not backed up.
+smbclient doesn't extract the WinXX ACLs, so file attributes other than the
+equivalent (as provided by smbclient) unix attributes are not backed up.
 
 =head3 Locked files are not backed up
 
-Under WinXX a locked file cannot be read by smbclient. Such files will
-not be backed up. This includes the WinXX system registry files.
+Under WinXX a locked file cannot be read by smbclient. Such files will not be
+backed up. This includes the WinXX system registry files.
 
-This is especially troublesome for Outlook, which stores all its data
-in a single large file and keeps it locked whenever it is running. Since
-many users keep Outlook running all the time their machine is up their
-Outlook file will not be backed up. Sadly, this file is the most important
-file to backup. As one workaround, Microsoft has a user-level application
-that periodically asks the user if they want to make a copy of their outlook.pst
-file. This copy can then be backed up by BackupPC. See L<http://office.microsoft.com/downloads/2002/pfbackup.aspx>.
+This is especially troublesome for Outlook, which stores all its data in a
+single large file and keeps it locked whenever it is running. Since many users
+keep Outlook running all the time their machine is up their Outlook file will
+not be backed up. Sadly, this file is the most important file to backup. As one
+workaround, Microsoft has a user-level application that periodically asks the
+user if they want to make a copy of their outlook.pst file. This copy can then
+be backed up by BackupPC. See
+L<http://office.microsoft.com/downloads/2002/pfbackup.aspx>.
 
-Similarly, all of the data for WinXX services like SQL databases, Exchange
-etc won't be backed up. If these applications support some kind of export or
+Similarly, all of the data for WinXX services like SQL databases, Exchange etc
+won't be backed up. If these applications support some kind of export or
 utility to save their data to disk then this can =used to create files that
 BackupPC can backup.
 
 So far, the best that BackupPC can do is send warning emails to the user saying
 that their outlook files haven't been backed up in X days. (X is configurable.)
-The message invites the user to exit Outlook and gives a URL to manually start a backup.
+The message invites the user to exit Outlook and gives a URL to manually start
+a backup.
 
-With Windows 2003 and WinXP the Volume Shadow feature (VSS) allows open files to
-be copied. VSS is the capability that creates volume snapshots for backup purposes.
-See L<http://blogs.msdn.com/adioltean/archive/2005/01/05/346793.aspx>.
+With Windows 2003 and WinXP the Volume Shadow feature (VSS) allows open files
+to be copied. VSS is the capability that creates volume snapshots for backup
+purposes. See
+L<http://blogs.msdn.com/adioltean/archive/2005/01/05/346793.aspx>.
 
 Comment: two users have noted that there are commercial OFM (open file manager)
 products that are designed to solve this problem, for example from St. Bernard
-or Columbia Data Products. Apparently Veritas and Legato bundle this product with
-their commercial products. See for example L<http://www.stbernard.com/products/docs/ofm_whitepaperV8.pdf>.
-If anyone tries these programs with BackupPC please tell us whether or not they work.
+or Columbia Data Products. Apparently Veritas and Legato bundle this product
+with their commercial products. See for example
+L<http://www.stbernard.com/products/docs/ofm_whitepaperV8.pdf>. If anyone tries
+these programs with BackupPC please tell us whether or not they work.
 
-Comment: Bacula (open source backup to disk) has implemented support for VSS, allowing open file
-backup. The on-going development of the BackupPCd client should eventually include similar VSS support,
-finally providing an open-file backup solution in BackupPC.
+Comment: Bacula (open source backup to disk) has implemented support for VSS,
+allowing open file backup. The on-going development of the BackupPCd client
+should eventually include similar VSS support, finally providing an open-file
+backup solution in BackupPC.
 
 =head3 Don't expect to reconstruct a complete WinXX drive
 
-The conclusion from the last few items is that BackupPC is not intended to allow a complete WinXX
-disk to be re-imaged from the backup. Our approach to system restore in the event of
-catastrophic failure is to re-image a new disk from a generic master, and then use the BackupPC
-archive to restore user files.
+The conclusion from the last few items is that BackupPC is not intended to
+allow a complete WinXX disk to be re-imaged from the backup. Our approach to
+system restore in the event of catastrophic failure is to re-image a new disk
+from a generic master, and then use the BackupPC archive to restore user files.
 
-It is likely that linux/unix backups done using tar (rather than smb) can be used to reconstruct a complete file system, although I haven't tried it.
+It is likely that linux/unix backups done using tar (rather than smb) can be
+used to reconstruct a complete file system, although I haven't tried it.
 
 =head3 Maximum Backup File Sizes
 
-BackupPC can backup and manage very large file sizes, probably as large as 2^51 bytes
-(when a double-precision number's mantissa can no longer represent an integer exactly).
-In practice, several things outside BackupPC limit the maximum individual file size. Any
-one of the following items will limit the maximum individual file size:
+BackupPC can backup and manage very large file sizes, probably as large as 2^51
+bytes (when a double-precision number's mantissa can no longer represent an
+integer exactly). In practice, several things outside BackupPC limit the
+maximum individual file size. Any one of the following items will limit the
+maximum individual file size:
 
 B<Perl>
 
 =over 4
 
-Perl needs to be compiled with uselargefiles defined. Check your installation with:
+Perl needs to be compiled with uselargefiles defined. Check your installation
+with:
 
 =over 4
 
@@ -3607,7 +3486,8 @@ B<Filesystem>
 
 =over 4
 
-The BackupPC pool and data directories must be on a file system that supports large files.
+The BackupPC pool and data directories must be on a file system that supports
+large files.
 
 Without this, the maximum file size will be 2GB.
 
@@ -3620,16 +3500,16 @@ B<Transport>
 The transport mechanism also limits the maximum individual file size. GNU tar
 maximum file size is limited by the tar header format. The tar header uses 11
 octal digits to represent the file size, which is 33 bits or 8GB. I vaguely
-recall (but I haven't recently checked) that GNU tar uses an extra octal
-digit (replacing a trailing delimiter) if necessary, allowing 64GB files.
-So tar transport limits the maximum file size to 8GB or perhaps 64GB. It is
-possible that files >= 8GB don't work; this needs to be looked into.
+recall (but I haven't recently checked) that GNU tar uses an extra octal digit
+(replacing a trailing delimiter) if necessary, allowing 64GB files. So tar
+transport limits the maximum file size to 8GB or perhaps 64GB. It is possible
+that files >= 8GB don't work; this needs to be looked into.
 
 Smbclient is limited to 4GB file sizes. Moreover, a bug in smbclient (mixing
 signed and unsigned 32 bit values) causes it to incorrectly do the tar octal
 conversion for file sizes from 2GB-4GB. BackupPC_tarExtract knows about this
-bug and can recover the correct file size. So smbclient transport works up
-to 4GB file sizes.
+bug and can recover the correct file size. So smbclient transport works up to
+4GB file sizes.
 
 Rsync running on Cygwin is limited to either 2GB or 4GB file sizes. More
 testing needs to be done to verify the file size limit for rsync on various
@@ -3640,20 +3520,20 @@ platforms.
 =head3 Some tape backup systems aren't smart about hard links
 
 If you backup the BackupPC pool to tape you need to make sure that the tape
-backup system is smart about hard links. For example, if you simply try to
-tar the BackupPC pool to tape you will backup a lot more data than is necessary.
+backup system is smart about hard links. For example, if you simply try to tar
+the BackupPC pool to tape you will backup a lot more data than is necessary.
 
-Using the example at the start of the installation section, 65 hosts are
-backed up with each full backup averaging 3.2GB. Storing one full backup and
-two incremental backups per laptop is around 240GB of raw data. But because of
-the pooling of identical files, only 87GB is used (with compression the total
-is lower). If you run du or tar on the data directory, there will appear to be
+Using the example at the start of the installation section, 65 hosts are backed
+up with each full backup averaging 3.2GB. Storing one full backup and two
+incremental backups per laptop is around 240GB of raw data. But because of the
+pooling of identical files, only 87GB is used (with compression the total is
+lower). If you run du or tar on the data directory, there will appear to be
 240GB of data, plus the size of the pool (around 87GB), or 327GB total.
 
 If your tape backup system is not smart about hard links an alternative is to
-periodically backup just the last successful backup for each host to tape. Another
-alternative is to do a low-level dump of the pool file system (ie: /dev/hda1 or similar)
-using dump(1).
+periodically backup just the last successful backup for each host to tape.
+Another alternative is to do a low-level dump of the pool file system (ie:
+/dev/hda1 or similar) using dump(1).
 
 Supporting more efficient tape backup is an area for further development.
 
@@ -3666,20 +3546,21 @@ mtime (modification time) of the files. Any files with modification times after
 This means that files that are deleted, renamed or extracted from an archive
 (preserving the original modification time) won't be backed up by an smbclient
 or tar incremental. Rsync, in contrast, inspects the complete list of files in
-an incremental and checks all the meta data: present or not, size, mtime, owner,
-group, permissions, and backs up all files with any changes to their meta data.
-Therefore, with rsync, incrementals are accurate, since any deleted, renamed or
-new files are correctly noticed.
+an incremental and checks all the meta data: present or not, size, mtime,
+owner, group, permissions, and backs up all files with any changes to their
+meta data. Therefore, with rsync, incrementals are accurate, since any deleted,
+renamed or new files are correctly noticed.
 
-To make browsing and restoring backups easier, incremental backups are I<filled-in>
-from the last complete backup when the backup is browsed or restored.
+To make browsing and restoring backups easier, incremental backups are
+I<filled-in> from the last complete backup when the backup is browsed or
+restored.
 
 This means the incremental view presented by BackupPC might not be accurate for
-smbclient and tar: deleted files, renamed files or files extracted from archives
-since the last full backup won't be noticed or displayed.
+smbclient and tar: deleted files, renamed files or files extracted from
+archives since the last full backup won't be noticed or displayed.
 
-The solution for SMB is to replace smbclient with FileSys::SmbClient. This will give
-BackupPC full access to the file attributes on the client.
+The solution for SMB is to replace smbclient with FileSys::SmbClient. This will
+give BackupPC full access to the file attributes on the client.
 
 Comments or suggestions on these issues are welcome.
 
@@ -3687,36 +3568,34 @@ Comments or suggestions on these issues are welcome.
 
 =head3 Smb share password
 
-An important security risk is the manner in which the smb share
-passwords are stored. They are in plain text. As described in
-L<Step 3: Setting up config.pl>, there are four ways to tell
-BackupPC the smb share password (manually setting an environment
-variable, setting the environment variable in /etc/init.d/backuppc,
-putting the password in __TOPDIR__/conf/config.pl, or putting the
-password in __TOPDIR__/pc/$host/config.pl). In the latter 3 cases
+An important security risk is the manner in which the smb share passwords are
+stored. They are in plain text. As described in L<Step 3: Setting up
+config.pl>, there are four ways to tell BackupPC the smb share password
+(manually setting an environment variable, setting the environment variable in
+/etc/init.d/backuppc, putting the password in __TOPDIR__/conf/config.pl, or
+putting the password in __TOPDIR__/pc/$host/config.pl). In the latter 3 cases
 the smb share password appears in plain text in a file.
 
-If you use any of the latter three methods please make sure that the
-file's permission is appropriately restricted. If you also use RCS
-or CVS, double check the file permissions of the config.pl,v file.
+If you use any of the latter three methods please make sure that the file's
+permission is appropriately restricted. If you also use RCS or CVS, double
+check the file permissions of the config.pl,v file.
 
-In future versions there will probably be support for encryption of
-the smb share password, but a private key will still have to be
-stored in a protected place. Comments and suggestions are welcome.
+In future versions there will probably be support for encryption of the smb
+share password, but a private key will still have to be stored in a protected
+place. Comments and suggestions are welcome.
 
 =head3 BackupPC socket server
 
-In v1.5.0 the primary method for communication between the CGI
-program (BackupPC_Admin) and the server (BackupPC) is via a unix-domain
-socket. Since this socket has restricted permissions, no local user
-should be able to connect to this port. No backup or restore data
-passes through this interface, but an attacker can start or stop
-backups and get status through this port.
+In v1.5.0 the primary method for communication between the CGI program
+(BackupPC_Admin) and the server (BackupPC) is via a unix-domain socket. Since
+this socket has restricted permissions, no local user should be able to connect
+to this port. No backup or restore data passes through this interface, but an
+attacker can start or stop backups and get status through this port.
 
-If the Apache server and BackupPC_Admin run on a different host to
-BackupPC then a TCP port must be enabled by setting $Conf{ServerPort}.
-Anyone can connect to this port. To avoid possible attacks via the TCP
-socket interface, every client message is protected by an MD5 digest.
+If the Apache server and BackupPC_Admin run on a different host to BackupPC
+then a TCP port must be enabled by setting $Conf{ServerPort}. Anyone can
+connect to this port. To avoid possible attacks via the TCP socket interface,
+every client message is protected by an MD5 digest.
 
 The MD5 digest includes four items:
 
@@ -3740,66 +3619,65 @@ the message itself.
 
 =back
 
-The message is sent in plain text preceded by the MD5 digest. A
-snooper can see the plain-text seed sent by BackupPC and plain-text
-message from the client, but cannot construct a valid MD5 digest
-since the secret in $Conf{ServerMesgSecret} is unknown. A replay
-attack is not possible since the seed changes on a per-connection
-and per-message basis.
+The message is sent in plain text preceded by the MD5 digest. A snooper can see
+the plain-text seed sent by BackupPC and plain-text message from the client,
+but cannot construct a valid MD5 digest since the secret in
+$Conf{ServerMesgSecret} is unknown. A replay attack is not possible since the
+seed changes on a per-connection and per-message basis.
 
-So if you do enable the TCP port, please set $Conf{ServerMesgSecret}
-to some hard-to-guess string. A denial-of-service attack is possible
-with the TCP port enabled. Someone could simply connect many times
-to this port, until BackupPC had exhausted all its file descriptors,
-and this would cause new backups and the CGI interface to fail. The
-most secure solution is to run BackupPC and Apache on the same
-machine and disable the TCP port.
+So if you do enable the TCP port, please set $Conf{ServerMesgSecret} to some
+hard-to-guess string. A denial-of-service attack is possible with the TCP port
+enabled. Someone could simply connect many times to this port, until BackupPC
+had exhausted all its file descriptors, and this would cause new backups and
+the CGI interface to fail. The most secure solution is to run BackupPC and
+Apache on the same machine and disable the TCP port.
 
-By the way, if you have upgraded from a version of BackupPC prior
-to v1.5.0 you should set $Conf{ServerPort} to -1 to disable the TCP port.
+By the way, if you have upgraded from a version of BackupPC prior to v1.5.0 you
+should set $Conf{ServerPort} to -1 to disable the TCP port.
 
 =head3 Installation permissions
 
-It is important to check that the BackupPC scripts in __INSTALLDIR__/bin
-and __INSTALLDIR__/lib cannot be edited by normal users. Check the
-directory permissions too.
+It is important to check that the BackupPC scripts in __INSTALLDIR__/bin and
+__INSTALLDIR__/lib cannot be edited by normal users. Check the directory
+permissions too.
 
 =head3 Pool permissions
 
-It is important to check that the data files in __TOPDIR__/pool,
-__TOPDIR__/pc and __TOPDIR__/trash cannot be read by normal users. Normal
-users should not be able to see anything below __TOPDIR__.
+It is important to check that the data files in __TOPDIR__/pool, __TOPDIR__/pc
+and __TOPDIR__/trash cannot be read by normal users. Normal users should not be
+able to see anything below __TOPDIR__.
 
 =head3 Host shares
 
 Enabling shares on hosts carries security risks. If you are on a private
 network and you generally trust your users then there should not be a problem.
-But if you have a laptop that is sometimes on public networks (eg: broadband
-or even dialup) you should be concerned. A conservative approach is to use
-firewall software, and only enable the netbios and smb ports (137 and 139)
-on connections from the host running BackupPC.
+But if you have a laptop that is sometimes on public networks (eg: broadband or
+even dialup) you should be concerned. A conservative approach is to use
+firewall software, and only enable the netbios and smb ports (137 and 139) on
+connections from the host running BackupPC.
 
 =head3 SSH key security
 
 Using ssh for linux/unix clients is quite secure, but the security is only as
 good as the protection of ssh's private keys. If an attacker can devise a way
 to run a shell as the BackupPC user then they will have access to BackupPC's
-private ssh keys. They can then, in turn, ssh to any client machine as root
-(or whichever user you have configured BackupPC to use). This represents a
-serious compromise of your entire network. So in vulnerable networks, think
-carefully about how to protect the machine running BackupPC and how to prevent
-attackers from gaining shell access (as the BackupPC user) to the machine.
+private ssh keys. They can then, in turn, ssh to any client machine as root (or
+whichever user you have configured BackupPC to use). This represents a serious
+compromise of your entire network. So in vulnerable networks, think carefully
+about how to protect the machine running BackupPC and how to prevent attackers
+from gaining shell access (as the BackupPC user) to the machine.
 
 =head3 CGI interface
 
-The CGI interface, __CGIDIR__/BackupPC_Admin, needs access to the pool files
-so it is installed setuid to __BACKUPPCUSER__. The permissions of this file
-need to checked carefully. It should be owned by __BACKUPPCUSER__ and have
-user and group (but not other) execute permission. To allow apache/httpd to
-execute it, the group ownership should be something that apache/httpd belongs to.
+The CGI interface, __CGIDIR__/BackupPC_Admin, needs access to the pool files so
+it is installed setuid to __BACKUPPCUSER__. The permissions of this file need
+to checked carefully. It should be owned by __BACKUPPCUSER__ and have user and
+group (but not other) execute permission. To allow apache/httpd to execute it,
+the group ownership should be something that apache/httpd belongs to.
 
-The Apache configuration should be setup for AuthConfig style, using a .htaccess
-file so that the user's name is passed into the script as $ENV{REMOTE_USER}.
+The Apache configuration should be setup for AuthConfig style, using a
+.htaccess file so that the user's name is passed into the script as
+$ENV{REMOTE_USER}.
 
 If normal users could directly run BackupPC_Admin then there is a serious
 security hole: since it is setuid to __BACKUPPCUSER__ any user can browse and
@@ -3810,32 +3688,32 @@ The exec succeeds since httpd runs the first script as user httpd/apache, which
 in turn has group permission to execute BackupPC_Admin.
 
 While this setup should be safe, a more conservative approach is to run a
-dedicated Apache as user __BACKUPPCUSER__ on a different port. Then BackupPC_Admin
-no longer needs to be setuid, and the cgi directories can be locked down from
-normal users. Moreover, this setup is exactly the one used to support mod_perl,
-so this provides both the highest performance and the lowest security risk.
+dedicated Apache as user __BACKUPPCUSER__ on a different port. Then
+BackupPC_Admin no longer needs to be setuid, and the cgi directories can be
+locked down from normal users. Moreover, this setup is exactly the one used to
+support mod_perl, so this provides both the highest performance and the lowest
+security risk.
 
 Comments and suggestions are welcome.
 
 =head1 Configuration File
 
-The BackupPC configuration file resides in __CONFDIR__/config.pl.
-Optional per-PC configuration files reside in __CONFDIR__/pc/$host.pl
-(or __TOPDIR__/pc/$host/config.pl in non-FHS versions of BackupPC).
-This file can be used to override settings just for a particular PC.
+The BackupPC configuration file resides in __CONFDIR__/config.pl. Optional
+per-PC configuration files reside in __CONFDIR__/pc/$host.pl (or
+__TOPDIR__/pc/$host/config.pl in non-FHS versions of BackupPC). This file can
+be used to override settings just for a particular PC.
 
 =head2 Modifying the main configuration file
 
-The configuration file is a perl script that is executed by BackupPC, so
-you should be careful to preserve the file syntax (punctuation, quotes
-etc) when you edit it. Specifically, preserving quotes means you should never
-use undef for configuration parameters that expect string values. An empty
-string ('') should be used in this case.
-It is recommended that you use CVS, RCS or some
+The configuration file is a perl script that is executed by BackupPC, so you
+should be careful to preserve the file syntax (punctuation, quotes etc) when
+you edit it. Specifically, preserving quotes means you should never use undef
+for configuration parameters that expect string values. An empty string ('')
+should be used in this case. It is recommended that you use CVS, RCS or some
 other method of source control for changing config.pl.
 
-BackupPC reads or re-reads the main configuration file and
-the hosts file in three cases:
+BackupPC reads or re-reads the main configuration file and the hosts file in
+three cases:
 
 =over 4
 
@@ -3845,48 +3723,46 @@ Upon startup.
 
 =item *
 
-When BackupPC is sent a HUP (-1) signal.  Assuming you installed the
-init.d script, you can also do this with "/etc/init.d/backuppc reload".
+When BackupPC is sent a HUP (-1) signal.  Assuming you installed the init.d
+script, you can also do this with "/etc/init.d/backuppc reload".
 
 =item *
 
-When the modification time of config.pl file changes.  BackupPC
-checks the modification time once during each regular wakeup.
+When the modification time of config.pl file changes.  BackupPC checks the
+modification time once during each regular wakeup.
 
 =back
 
-Whenever you change the configuration file you can either do
-a kill -HUP BackupPC_pid or simply wait until the next regular
-wakeup period.
+Whenever you change the configuration file you can either do a kill -HUP
+BackupPC_pid or simply wait until the next regular wakeup period.
 
-Each time the configuration file is re-read a message is reported in the
-LOG file, so you can tail it (or view it via the CGI interface) to make
-sure your kill -HUP worked. Errors in parsing the configuration file are
-also reported in the LOG file.
+Each time the configuration file is re-read a message is reported in the LOG
+file, so you can tail it (or view it via the CGI interface) to make sure your
+kill -HUP worked. Errors in parsing the configuration file are also reported in
+the LOG file.
 
 The optional per-PC configuration file (__CONFDIR__/pc/$host.pl or
-__TOPDIR__/pc/$host/config.pl in non-FHS versions of BackupPC)
-is read whenever it is needed by BackupPC_dump, BackupPC_restore and others.
+__TOPDIR__/pc/$host/config.pl in non-FHS versions of BackupPC) is read whenever
+it is needed by BackupPC_dump, BackupPC_restore and others.
 
 =head1 Configuration Parameters
 
-The configuration parameters are divided into five general groups.
-The first group (general server configuration) provides general
-configuration for BackupPC.  The next two groups describe what to
-backup, when to do it, and how long to keep it.  The fourth group
-are settings for email reminders, and the final group contains
-settings for the CGI interface.
+The configuration parameters are divided into five general groups. The first
+group (general server configuration) provides general configuration for
+BackupPC.  The next two groups describe what to backup, when to do it, and how
+long to keep it.  The fourth group are settings for email reminders, and the
+final group contains settings for the CGI interface.
 
-All configuration settings in the second through fifth groups can
-be overridden by the per-PC config.pl file.
+All configuration settings in the second through fifth groups can be overridden
+by the per-PC config.pl file.
 
 __CONFIGPOD__
 
 =head1 Version Numbers
 
-BackupPC uses a X.Y.Z version numbering system.  The first digit is for
-major new releases, the middle digit is for significant feature releases
-and improvements (most of the releases have been in this category).
+BackupPC uses a X.Y.Z version numbering system.  The first digit is for major
+new releases, the middle digit is for significant feature releases and
+improvements (most of the releases have been in this category).
 
 =head1 Author
 
@@ -3900,19 +3776,18 @@ Copyright (C) 2001-2020 Craig Barratt
 
 =head1 Credits
 
-Ryan Kucera contributed the directory navigation code and images
-for v1.5.0.  He contributed the first skeleton of BackupPC_restore.
-He also added a significant revision to the CGI interface, including
-CSS tags, in v2.1.0, and designed the BackupPC logo.
+Ryan Kucera contributed the directory navigation code and images for v1.5.0. He
+contributed the first skeleton of BackupPC_restore. He also added a significant
+revision to the CGI interface, including CSS tags, in v2.1.0, and designed the
+BackupPC logo.
 
 Xavier Nicollet, with additions from Guillaume Filion, added the
-internationalization (i18n) support to the CGI interface for v2.0.0.
-Xavier provided the French translation fr.pm, with additions from
-Guillaume.
+internationalization (i18n) support to the CGI interface for v2.0.0. Xavier
+provided the French translation fr.pm, with additions from Guillaume.
 
-Guillaume Filion wrote BackupPC_zipCreate and added the CGI support
-for zip download, in addition to some CGI cleanup, for v1.5.0.
-Guillaume continues to support fr.pm updates for each new version.
+Guillaume Filion wrote BackupPC_zipCreate and added the CGI support for zip
+download, in addition to some CGI cleanup, for v1.5.0. Guillaume continues to
+support fr.pm updates for each new version.
 
 Josh Marshall implemented the Archive feature in v2.1.0.
 
@@ -3920,24 +3795,24 @@ Ludovic Drolez supports the BackupPC Debian package.
 
 Javier Gonzalez provided the Spanish translation, es.pm for v2.0.0.
 
-Manfred Herrmann provided the German translation, de.pm for v2.0.0.
-Manfred continues to support de.pm updates for each new version,
-together with some help from Ralph Paßgang.
+Manfred Herrmann provided the German translation, de.pm for v2.0.0. Manfred
+continues to support de.pm updates for each new version, together with some
+help from Ralph Paßgang.
 
 Lorenzo Cappelletti provided the Italian translation, it.pm for v2.1.0.
 Giuseppe Iuculano and Vittorio Macchi updated it for 3.0.0.
 
-Lieven Bridts provided the Dutch translation, nl.pm, for v2.1.0,
-with some tweaks from Guus Houtzager, and updates for 3.0.0.
+Lieven Bridts provided the Dutch translation, nl.pm, for v2.1.0, with some
+tweaks from Guus Houtzager, and updates for 3.0.0.
 
-Reginaldo Ferreira provided the Portuguese Brazilian translation
-pt_br.pm for v2.2.0.
+Reginaldo Ferreira provided the Portuguese Brazilian translation pt_br.pm for
+v2.2.0.
 
 Rich Duzenbury provided the RSS feed option to the CGI interface.
 
-Jono Woodhouse from CapeSoft Software (www.capesoft.com) provided a
-new CSS skin for 3.0.0 with several layout improvements.  Sean Cameron
-(also from CapeSoft) designed new and more compact file icons for 3.0.0.
+Jono Woodhouse from CapeSoft Software (www.capesoft.com) provided a new CSS
+skin for 3.0.0 with several layout improvements.  Sean Cameron (also from
+CapeSoft) designed new and more compact file icons for 3.0.0.
 
 Youlin Feng provided the Chinese translation for 3.1.0.
 
@@ -3958,23 +3833,24 @@ Sergei Butakov provided the Russian translation for 3.3.0.
 Alexander Moisseev provided the rrdtool graphing code in 4.0.0 and has provided
 many fixes and improvements in 3.x and 4.x.
 
-Many people have provided user support on the mail lists, reported bugs,
-made useful suggestions, and helped with testing; see the ChangeLog
-and the mailing lists.
+Many people have provided user support on the mail lists, reported bugs, made
+useful suggestions, and helped with testing; see the ChangeLog and the mailing
+lists.
 
 Your name could appear here in the next version!
 
 =head1 License
 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later
+version.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+This program is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+You should have received a copy of the GNU General Public License along with
+this program.  If not, see <http://www.gnu.org/licenses/>.
+
+=cut

--- a/lib/Net/FTP/AutoReconnect.pm
+++ b/lib/Net/FTP/AutoReconnect.pm
@@ -12,62 +12,57 @@ Net::FTP::AutoReconnect - FTP client class with automatic reconnect on failure
 
 =head1 SYNOPSIS
 
-C<Net::FTP::AutoReconnect> is a wrapper module around C<Net::FTP>.
-For many commands, if anything goes wrong on the first try, it tries
-to disconnect and reconnect to the server, restore the state to the
-same as it was when the command was executed, then execute it again.
-The state includes login credentials, authorize credentials, transfer
-mode (ASCII or binary), current working directory, and any restart,
-passive, or port commands sent.
+C<Net::FTP::AutoReconnect> is a wrapper module around C<Net::FTP>. For many
+commands, if anything goes wrong on the first try, it tries to disconnect and
+reconnect to the server, restore the state to the same as it was when the
+command was executed, then execute it again. The state includes login
+credentials, authorize credentials, transfer mode (ASCII or binary), current
+working directory, and any restart, passive, or port commands sent.
 
 =head1 DESCRIPTION
 
-The goal of this method is to hide some implementation details of FTP
-server systems from the programmer.  In particular, many FTP systems
-will automatically disconnect a user after a relatively short idle
-time or after a transfer is aborted.  In this case,
-C<Net::FTP::AutoReconnect> will simply reconnect, send the commands
-necessary to return your session to its previous state, then resend
-the command.  If that fails, it will return the error.
+The goal of this method is to hide some implementation details of FTP server
+systems from the programmer.  In particular, many FTP systems will
+automatically disconnect a user after a relatively short idle time or after a
+transfer is aborted.  In this case, C<Net::FTP::AutoReconnect> will simply
+reconnect, send the commands necessary to return your session to its previous
+state, then resend the command.  If that fails, it will return the error.
 
-It makes no effort to determine what sorts of errors are likely to
-succeed when they're retried.  Partly that's because it's hard to
-know; if you're retrieving a file from an FTP site with several
-mirrors and the file is not found, for example, maybe on the next try
-you'll connect to a different server and find it.  But mostly it's
-from laziness; if you have some good ideas about how to determine when
-to retry and when not to bother, by all means send patches.
+It makes no effort to determine what sorts of errors are likely to succeed when
+they're retried.  Partly that's because it's hard to know; if you're retrieving
+a file from an FTP site with several mirrors and the file is not found, for
+example, maybe on the next try you'll connect to a different server and find
+it.  But mostly it's from laziness; if you have some good ideas about how to
+determine when to retry and when not to bother, by all means send patches.
 
-This module contains an instance of C<Net::FTP>, which it passes most
-method calls along to.
+This module contains an instance of C<Net::FTP>, which it passes most method
+calls along to.
 
-These methods also record their state: C<alloc>, C<ascii>,
-C<authorize>, C<binary>, C<cdup>, C<cwd>, C<hash>,
-C<login>,C<restart>, C<pasv>, C<port>.  Directory changing commands
-execute a C<pwd> afterwards and store their new working directory.
+These methods also record their state: C<alloc>, C<ascii>, C<authorize>,
+C<binary>, C<cdup>, C<cwd>, C<hash>, C<login>,C<restart>, C<pasv>, C<port>.
+Directory changing commands execute a C<pwd> afterwards and store their new
+working directory.
 
 These methods are automatically retried: C<alloc>, C<appe>, C<append>,
-C<ascii>, C<binary>, C<cdup>, C<cwd>, C<delete>, C<dir>, C<get>,
-C<list>, C<ls>, C<mdtm>, C<mkdir>, C<nlst>, C<pasv>, C<port>, C<put>,
-C<put_unique>, C<pwd>, C<rename>, C<retr>, C<rmdir>, C<size>, C<stou>,
-C<supported>.
+C<ascii>, C<binary>, C<cdup>, C<cwd>, C<delete>, C<dir>, C<get>, C<list>,
+C<ls>, C<mdtm>, C<mkdir>, C<nlst>, C<pasv>, C<port>, C<put>, C<put_unique>,
+C<pwd>, C<rename>, C<retr>, C<rmdir>, C<size>, C<stou>, C<supported>.
 
-These methods are tried just once: C<abort>, C<authorize>, C<hash>,
-C<login>, C<pasv_xfer>, C<pasv_xfer_unique>, C<pasv_wait>, C<quit>,
-C<restart>, C<site>, C<unique_name>.  From C<Net::Cmd>: C<code>,
-C<message>, C<ok>, C<status>.  C<restart> doesn't actually send any
-FTP commands (they're sent along with the command they apply to),
-which is why it's not restarted.
+These methods are tried just once: C<abort>, C<authorize>, C<hash>, C<login>,
+C<pasv_xfer>, C<pasv_xfer_unique>, C<pasv_wait>, C<quit>, C<restart>, C<site>,
+C<unique_name>.  From C<Net::Cmd>: C<code>, C<message>, C<ok>, C<status>.
+C<restart> doesn't actually send any FTP commands (they're sent along with the
+command they apply to), which is why it's not restarted.
 
-Any other commands are unimplemented (or possibly misdocumented); if I
-missed one you'd like, please send a patch.
+Any other commands are unimplemented (or possibly misdocumented); if I missed
+one you'd like, please send a patch.
 
 =head2 CONSTRUCTOR
 
 =head3 new
 
-All parameters are passed along verbatim to C<Net::FTP>, as well as
-stored in case we have to reconnect.
+All parameters are passed along verbatim to C<Net::FTP>, as well as stored in
+case we have to reconnect.
 
 =cut
 
@@ -85,13 +80,13 @@ sub new
 
 =head2 METHODS
 
-Most of the methods are those of L<Net::FTP|Net::FTP>.  One additional
-method is available:
+Most of the methods are those of L<Net::FTP|Net::FTP>.  One additional method
+is available:
 
 =head3 reconnect()
 
-Abandon the current FTP connection and create a new one, restoring all
-the state we can.
+Abandon the current FTP connection and create a new one, restoring all the
+state we can.
 
 =cut
 
@@ -468,14 +463,12 @@ Scott Gifford <sgifford@suspectclass.com>
 
 We should really be smarter about when to retry.
 
-We shouldn't be hardwired to use C<Net::FTP>, but any FTP-compatible
-class; that would allow all modules similar to this one to be chained
-together.
+We shouldn't be hardwired to use C<Net::FTP>, but any FTP-compatible class;
+that would allow all modules similar to this one to be chained together.
 
-Much of this is only lightly tested; it's hard to find an FTP server
-unreliable enough to test all aspects of it.  It's mostly been tested
-with a server that dicsonnects after an aborted transfer, and the
-module seems to work OK.
+Much of this is only lightly tested; it's hard to find an FTP server unreliable
+enough to test all aspects of it.  It's mostly been tested with a server that
+dicsonnects after an aborted transfer, and the module seems to work OK.
 
 =head1 SEE ALSO
 
@@ -483,9 +476,9 @@ L<Net::FTP>.
 
 =head1 COPYRIGHT
 
-Copyright (c) 2006 Scott Gifford. All rights reserved.  This program
-is free software; you can redistribute it and/or modify it under the
-same terms as Perl itself.
+Copyright (c) 2006 Scott Gifford. All rights reserved.  This program is free
+software; you can redistribute it and/or modify it under the same terms as Perl
+itself.
 
 =cut
 

--- a/lib/Net/FTP/RetrHandle.pm
+++ b/lib/Net/FTP/RetrHandle.pm
@@ -17,42 +17,41 @@ use Scalar::Util;
 
 =head1 NAME
 
-Net::FTP::RetrHandle - Tied or IO::Handle-compatible interface to a file retrieved by FTP
+Net::FTP::RetrHandle - Tied or IO::Handle-compatible interface to a file
+retrieved by FTP
 
 =head1 SYNOPSIS
 
-Provides a file reading interface for reading all or parts of files
-located on a remote FTP server, including emulation of C<seek> and
-support for downloading only the parts of the file requested.
+Provides a file reading interface for reading all or parts of files located on
+a remote FTP server, including emulation of C<seek> and support for downloading
+only the parts of the file requested.
 
 =head1 DESCRIPTION
 
-Support for skipping the beginning of the file is implemented with the
-FTP C<REST> command, which starts a retrieval at any point in the
-file.  Support for skipping the end of the file is implemented with
-the FTP C<ABOR> command, which stops the transfer.  With these two
-commands and some careful tracking of the current file position, we're
-able to reliably emulate a C<seek/read> pair, and get only the parts
-of the file that are actually read.
+Support for skipping the beginning of the file is implemented with the FTP
+C<REST> command, which starts a retrieval at any point in the file.  Support
+for skipping the end of the file is implemented with the FTP C<ABOR> command,
+which stops the transfer.  With these two commands and some careful tracking of
+the current file position, we're able to reliably emulate a C<seek/read> pair,
+and get only the parts of the file that are actually read.
 
-This was originally designed for use with
-L<Archive::Zip|Archive::Zip>; it's reliable enough that the table of
-contents and individual files can be extracted from a remote ZIP
-archive without downloading the whole thing.  See L<EXAMPLES> below.
+This was originally designed for use with L<Archive::Zip|Archive::Zip>; it's
+reliable enough that the table of contents and individual files can be
+extracted from a remote ZIP archive without downloading the whole thing.  See
+L<EXAMPLES> below.
 
-An interface compatible with L<IO::Handle|IO::Handle> is provided,
-along with a C<tie>-based interface.
+An interface compatible with L<IO::Handle|IO::Handle> is provided, along with a
+C<tie>-based interface.
 
-Remember that an FTP server can only do one thing at a time, so make
-sure to C<close> your connection before asking the FTP server to do
-nything else.
+Remember that an FTP server can only do one thing at a time, so make sure to
+C<close> your connection before asking the FTP server to do nything else.
 
 =head1 CONSTRUCTOR
 
 =head2 new ( $ftp, $filename, options... )
 
-Creates a new L<IO::Handle|IO::Handle>-compatible object to fetch all
-or parts of C<$filename> using the FTP connection C<$ftp>.
+Creates a new L<IO::Handle|IO::Handle>-compatible object to fetch all or parts
+of C<$filename> using the FTP connection C<$ftp>.
 
 Available options:
 
@@ -60,23 +59,22 @@ Available options:
 
 =item MaxSkipSize => $size
 
-If we need to move forward in a file or close the connection,
-sometimes it's faster to just read the bytes we don't need than to
-abort the connection and restart. This setting tells how many
-unnecessary bytes we're willing to read rather than abort.  An
-appropriate setting depends on the speed of transferring files and the
-speed of reconnecting to the server.
+If we need to move forward in a file or close the connection, sometimes it's
+faster to just read the bytes we don't need than to abort the connection and
+restart. This setting tells how many unnecessary bytes we're willing to read
+rather than abort.  An appropriate setting depends on the speed of transferring
+files and the speed of reconnecting to the server.
 
 =item BlockSize => $size
 
-When doing buffered reads, how many bytes to read at once.  The
-default is the same as the default for L<Net::FTP|Net::FTP>, so it's
-generally best to leave it alone.
+When doing buffered reads, how many bytes to read at once.  The default is the
+same as the default for L<Net::FTP|Net::FTP>, so it's generally best to leave
+it alone.
 
 =item AlreadyBinary => $bool
 
-If set to a true value, we assume the server is already in binary
-mode, and don't try to set it.
+If set to a true value, we assume the server is already in binary mode, and
+don't try to set it.
 
 =back
 
@@ -114,8 +112,8 @@ Most of the methods implemented behave exactly like those from
 L<IO::Handle|IO::Handle>.
 
 These methods are implemented: C<binmode>, C<clearerr>, C<close>, C<eof>,
-C<error>, C<getc>, C<getline>, C<getlines>, C<getpos>, C<read>,
-C<seek>, C<setpos>, C<sysseek>, C<tell>, C<ungetc>, C<opened>.
+C<error>, C<getc>, C<getline>, C<getlines>, C<getpos>, C<read>, C<seek>,
+C<setpos>, C<sysseek>, C<tell>, C<ungetc>, C<opened>.
 
 =cut
 
@@ -514,9 +512,9 @@ sub DESTROY
 
 =head1 TIED INTERFACE
 
-Instead of a L<IO::Handle|IO::Handle>-compatible interface, you can
-use a C<tie>-based interface to use the standard Perl I/O operators.
-You can use it like this:
+Instead of a L<IO::Handle|IO::Handle>-compatible interface, you can use a
+C<tie>-based interface to use the standard Perl I/O operators. You can use it
+like this:
 
   use Net::FTP::RetrHandle;
   # Create FTP object in $ftp
@@ -590,8 +588,7 @@ sub UNTIE
 
 =head1 EXAMPLE
 
-Here's an example of listing a Zip file without downloading the whole
-thing:
+Here's an example of listing a Zip file without downloading the whole thing:
 
     #!/usr/bin/perl
 
@@ -626,16 +623,15 @@ Scott Gifford <sgifford@suspectclass.com>
 =head1 BUGS
 
 The distinction between tied filehandles and C<IO::Handle>-compatible
-filehandles should be blurrier.  It seems like other file handle
-objects you can freely mix method calls and traditional Perl
-operations, but I can't figure out how to do it.
+filehandles should be blurrier.  It seems like other file handle objects you
+can freely mix method calls and traditional Perl operations, but I can't figure
+out how to do it.
 
-Many FTP servers don't like frequent connection aborts.  If that's the
-case, try L<Net::FTP::AutoReconnect>, which will hide much of that
-from you.
+Many FTP servers don't like frequent connection aborts.  If that's the case,
+try L<Net::FTP::AutoReconnect>, which will hide much of that from you.
 
-If the filehandle is tied and created with C<gensym>, C<readline>
-doesn't work with older versions of Perl.  No idea why.
+If the filehandle is tied and created with C<gensym>, C<readline> doesn't work
+with older versions of Perl.  No idea why.
 
 =head1 SEE ALSO
 
@@ -643,9 +639,9 @@ L<Net::FTP>, L<Net::FTP::AutoReconnect>, L<IO::Handle>.
 
 =head1 COPYRIGHT
 
-Copyright (c) 2006 Scott Gifford. All rights reserved.  This program
-is free software; you can redistribute it and/or modify it under the
-same terms as Perl itself.
+Copyright (c) 2006 Scott Gifford. All rights reserved.  This program is free
+software; you can redistribute it and/or modify it under the same terms as Perl
+itself.
 
 =cut
 


### PR DESCRIPTION
@craigbarratt To use `thekevjames/linter` orb on CircleCI you need to allow using third party orbs in `Organization Settings / Security`.
Now we can disable Travis tests completely. You can turn off builds for the repo in the repositories list on Travis account page. Deleting or changing `.travis.yml` file is not necessary. 
