### PR TITLE
BackupPC-Check

### DIFF
--- a/bin/BackupPC_Admin_SCGI
+++ b/bin/BackupPC_Admin_SCGI
@@ -119,6 +119,7 @@ my %ActionDispatch = (
     "keepBackup"           => "HostInfo",
     "rss"                  => "Metrics",
     "metrics"              => "Metrics",
+    "check"                => "Check",
 );
 my %ChildPid2Num;
 

--- a/cgi-bin/BackupPC_Admin
+++ b/cgi-bin/BackupPC_Admin
@@ -85,6 +85,7 @@ my %ActionDispatch = (
     "keepBackup"           => "HostInfo",
     "rss"                  => "Metrics",
     "metrics"              => "Metrics",
+    "check"                => "Check",
 );
 
 #

--- a/conf/config.pl
+++ b/conf/config.pl
@@ -2185,7 +2185,7 @@ $Conf{CgiNavBarLinks} = [
     },
     {
         link  => "?action=check",
-        lname => "Check",            # displays BackupPC-Check module
+        lname => "Check",            # actually displays $Lang->{Check} for BackupPC-Check module
     },
     {
         link => "https://github.com/backuppc/backuppc/wiki",

--- a/conf/config.pl
+++ b/conf/config.pl
@@ -2184,6 +2184,10 @@ $Conf{CgiNavBarLinks} = [
         lname => "Documentation",            # actually displays $Lang->{Documentation}
     },
     {
+        link  => "?action=check",
+        lname => "Check",            # displays BackupPC-Check module
+    },
+    {
         link => "https://github.com/backuppc/backuppc/wiki",
         name => "Wiki",                                        # displays literal "Wiki"
     },

--- a/cpanfile
+++ b/cpanfile
@@ -4,3 +4,4 @@ requires 'CGI';
 requires 'File::Listing';
 requires 'Time::ParseDate';
 requires 'SCGI';
+requires 'Statistics::Descriptive';

--- a/lib/BackupPC/CGI/Check.pm
+++ b/lib/BackupPC/CGI/Check.pm
@@ -11,7 +11,10 @@
 #
 #========================================================================
 #
-# Released November 2019 - firewall-services.com
+# firewall-services.com
+# Version 1.0.0, released Feb 2021.
+#
+# See https://git.fws.fr/fws/BackupPC-Check
 #
 #========================================================================
 

--- a/lib/BackupPC/CGI/Check.pm
+++ b/lib/BackupPC/CGI/Check.pm
@@ -53,16 +53,16 @@ sub action
         $frequency = $Conf{FullPeriod};
       }
 
-      # ID
+      # Get ID of last backup
       my $idBackup = $Backups[@Backups-1]->{num} if ( @Backups );
 
-      # Age
+      # Get age of last backup
       my $lastBackup = ( $Backups[-1]->{type} =~ m/^full|incr$/ ) ? -1 : -2;
       $lastAge = sprintf("%.1f", (time - $Backups[$lastBackup]->{startTime}) / (24 * 3600));
 
-      # Color for age
+      # Color for age old
       if ( $lastAge < $frequency ) {
-          $lastAgeColor = "MediumSeaGreen";
+        $lastAgeColor = "MediumSeaGreen";
       } else {
         $lastAgeColor = "Tomato";
       }
@@ -70,24 +70,24 @@ sub action
       # Color and link for errors
       $lastXferErrors = $Backups[@Backups-1]->{xferErrs} if ( @Backups );
       if ( $lastXferErrors == 0 ) {
-          $lastXferErrorsColor = "MediumSeaGreen";
-          $ifErrors = "";
+        $lastXferErrorsColor = "MediumSeaGreen";
+        $ifErrors = "";
       } else {
         $lastXferErrorsColor = "Tomato";
         my $browseErrors = "?action=view&type=XferErr&num=$idBackup&host=$host";
         $ifErrors = "| <a href=\"$browseErrors\" target=\"_blank\"><strong>Read me !</strong></a>";
       }
 
-      # Colors statuts
+      # Colors statuts of backup
       $reasonHilite = $Conf{CgiStatusHilightColor}{$Status{$host}{reason}} || $Conf{CgiStatusHilightColor}{$Status{$host}{state}};
       $reasonHilite = " bgcolor=\"$reasonHilite\"" if ( $reasonHilite ne "" );
 
       # Check Size Consistency
-      my $new_size        = 0;
-      my $new_size_avg    = 0;
-      my $new_size_q1     = 0;
-      my $new_size_q3     = 0;
-      my $sizes           = new Statistics::Descriptive::Full;
+      my $new_size = 0;
+      my $new_size_avg = 0;
+      my $new_size_q1 = 0;
+      my $new_size_q3 = 0;
+      my $sizes = new Statistics::Descriptive::Full;
 
       foreach my $backup ( @Backups ) {
         my $idBackup = $Backups[@Backups-1]->{num} if ( @Backups );
@@ -99,29 +99,29 @@ sub action
 
         # Ignore the last backup if it's not full or incr (which means it's either partial or active)
         my $i = ( $Backups[-1]->{type} =~ m/^full|incr$/ ) ? -1 : -2;
-        $new_size          = $Backups[$i]->{sizeNew};
-        $new_size_avg      = int $sizes->mean;
-        $new_size_q1       = eval { int $sizes->quantile(1) } || 0;
-        $new_size_q3       = eval { int $sizes->quantile(3) } || 0;
+        $new_size = $Backups[$i]->{sizeNew};
+        $new_size_avg = int $sizes->mean;
+        $new_size_q1 = eval { int $sizes->quantile(1) } || 0;
+        $new_size_q3 = eval { int $sizes->quantile(3) } || 0;
       }
 
-      # Using a mathematical formula to calculate the consistency of the average size, for new files, on all backups
+      # Using a mathematical formula to calculate the consistency of the average size, for new files, on all backups :
       my $toobig = 0;
       my $toosmall = 0;
       my $sizeConsistencyColor = "Tomato";
       my $sizeConsistency = "<strong>ANOMALOUS</strong>";
 
-      # TOO BIG ? If the size is 3 times higher than usual :
+      # Too big ? If the size is 3 times higher than usual :
       if ( $new_size > ($new_size_q3 + ($new_size_q3 - $new_size_q1) ) * 1.5 and $new_size > $new_size_avg * 3 ) {
         $toobig = 1;
       }
 
-      # TOO SMALL ? If the size is 3 times lower than usual :
+      # Too small ? If the size is 3 times lower than usual :
       if ( $new_size < ($new_size_q1 - ($new_size_q3 - $new_size_q1) ) * 1.5 and $new_size < $new_size_avg / 3 ) {
         $toosmall = 1;
       }
 
-      # Get result
+      # Get result, if we don't have enough backup (< 4) we can't calcul a realist average
       if ( not $idBackup > 4) {
         $sizeConsistencyColor = "Gray";
         $sizeConsistency = "Not enough backups";
@@ -180,7 +180,7 @@ EOF
     </table>
 EOF
 
-    # Show page
+
     my $content = eval ("qq{$header}");
     Header("BackupPC: Check", $content);
     Trailer();

--- a/lib/BackupPC/CGI/Check.pm
+++ b/lib/BackupPC/CGI/Check.pm
@@ -137,7 +137,7 @@ sub action
       # Show summary
       $str .= <<EOF;
       <tr$reasonHilite>
-        <td class="border"><a href="$browseFile" target="_blank">$host ($idBackup)</a></td>
+        <td class="border"><a href="$browseFile">$host ($idBackup)</a></td>
         <td align="center" class="border" style="color:$lastAgeColor;">$lastAge <em>(Freq: $frequency)</em></td>
         <td align="center" class="border" style="color:$lastXferErrorsColor;">$lastXferErrors $ifErrors</td>
         <td align="center" class="border" style="color:$sizeConsistencyColor;">$sizeConsistency</td>

--- a/lib/BackupPC/CGI/Check.pm
+++ b/lib/BackupPC/CGI/Check.pm
@@ -1,0 +1,186 @@
+#============================================================= -*-perl-*-
+#
+# BackupPC::CGI::Check package
+#
+# DESCRIPTION
+#
+#   This module implements the Check action for the CGI interface.
+#
+# AUTHOR
+#   Heuze Florent  <heuzef@firewall-services.com>
+#
+#========================================================================
+#
+# Released November 2019 - firewall-services.com
+#
+#========================================================================
+
+package BackupPC::CGI::Check;
+
+use strict;
+use lib "/usr/share/BackupPC/lib";
+use BackupPC::Lib;
+use BackupPC::CGI::Lib qw(:all);
+use Statistics::Descriptive;
+
+sub action
+{
+    # Init
+    my($str, $strGood, $header);
+    GetStatusInfo("hosts info");
+    my $Privileged = CheckPermission();
+    my $bpc = BackupPC::Lib->new();
+
+    # Start loop
+    foreach my $host ( GetUserHosts(1) ) {
+      my($incrAge, $reasonHilite, $frequency, $idBackup, $lastAge, $lastAgeColor, $tempState, $tempReason, $lastXferErrors, $lastXferErrorsColor, $ifErrors, $sizeConsistency, $sizeConsistencyColor);
+      my($shortErr);
+      my @Backups = $bpc->BackupInfoRead($host);
+
+      $bpc->ConfigRead($host);
+      %Conf = $bpc->Conf();
+
+      next if ( $Conf{XferMethod} eq "archive" );
+      next if ( !$Privileged && !CheckPermission($host) );
+
+      # Get frequency for this host
+      if ( $Conf{IncrPeriod} < $Conf{FullPeriod} ) {
+        $frequency = $Conf{IncrPeriod};
+      } else {
+        $frequency = $Conf{FullPeriod};
+      }
+
+      # ID
+      my $idBackup = $Backups[@Backups-1]->{num} if ( @Backups );
+
+      # Age
+      my $lastBackup = ( $Backups[-1]->{type} =~ m/^full|incr$/ ) ? -1 : -2;
+      $lastAge = sprintf("%.1f", (time - $Backups[$lastBackup]->{startTime}) / (24 * 3600));
+
+      # Color for age
+      if ( $lastAge < $frequency ) {
+          $lastAgeColor = "MediumSeaGreen";
+      } else {
+        $lastAgeColor = "Tomato";
+      }
+
+      # Color and link for errors
+      $lastXferErrors = $Backups[@Backups-1]->{xferErrs} if ( @Backups );
+      if ( $lastXferErrors == 0 ) {
+          $lastXferErrorsColor = "MediumSeaGreen";
+          $ifErrors = "";
+      } else {
+        $lastXferErrorsColor = "Tomato";
+        my $browseErrors = "?action=view&type=XferErr&num=$idBackup&host=$host";
+        $ifErrors = "| <a href=\"$browseErrors\" target=\"_blank\"><strong>Read me !</strong></a>";
+      }
+
+      # Colors statuts
+      $reasonHilite = $Conf{CgiStatusHilightColor}{$Status{$host}{reason}} || $Conf{CgiStatusHilightColor}{$Status{$host}{state}};
+      $reasonHilite = " bgcolor=\"$reasonHilite\"" if ( $reasonHilite ne "" );
+
+      # Check Size Consistency
+      my $new_size        = 0;
+      my $new_size_avg    = 0;
+      my $new_size_q1     = 0;
+      my $new_size_q3     = 0;
+      my $sizes           = new Statistics::Descriptive::Full;
+
+      foreach my $backup ( @Backups ) {
+        my $idBackup = $Backups[@Backups-1]->{num} if ( @Backups );
+        # Skip partial or active backups
+        next if ( $backup->{type} !~ m/^full|incr$/ );
+        # Push all the sizes in our data set to compute avg sizes
+        # Exclude backup N°0 as it'll always have much more new data than normal backups
+        $sizes->add_data($backup->{sizeNew}) unless ( $backup->{num} == 0 );
+
+        # Ignore the last backup if it's not full or incr (which means it's either partial or active)
+        my $i = ( $Backups[-1]->{type} =~ m/^full|incr$/ ) ? -1 : -2;
+        $new_size          = $Backups[$i]->{sizeNew};
+        $new_size_avg      = int $sizes->mean;
+        $new_size_q1       = eval { int $sizes->quantile(1) } || 0;
+        $new_size_q3       = eval { int $sizes->quantile(3) } || 0;
+      }
+
+      # Using a mathematical formula to calculate the consistency of the average size, for new files, on all backups
+      my $toobig = 0;
+      my $toosmall = 0;
+      my $sizeConsistencyColor = "Tomato";
+      my $sizeConsistency = "<strong>ANOMALOUS</strong>";
+
+      # TOO BIG ? If the size is 3 times higher than usual :
+      if ( $new_size > ($new_size_q3 + ($new_size_q3 - $new_size_q1) ) * 1.5 and $new_size > $new_size_avg * 3 ) {
+        $toobig = 1;
+      }
+
+      # TOO SMALL ? If the size is 3 times lower than usual :
+      if ( $new_size < ($new_size_q1 - ($new_size_q3 - $new_size_q1) ) * 1.5 and $new_size < $new_size_avg / 3 ) {
+        $toosmall = 1;
+      }
+
+      # Get result
+      if ( not $idBackup > 4) {
+        $sizeConsistencyColor = "Gray";
+        $sizeConsistency = "Not enough backups";
+      }
+      elsif ( not $toobig and not $toosmall and not $idBackup < 4) {
+        $sizeConsistencyColor = "MediumSeaGreen";
+        $sizeConsistency = "Normal";
+      }
+
+      # Get URL for explore file
+      my $browseFile = "?action=browse&host=$host";
+
+      # Show summary
+      $str .= <<EOF;
+      <tr$reasonHilite>
+        <td class="border"><a href="$browseFile" target="_blank">$host ($idBackup)</a></td>
+        <td align="center" class="border" style="color:$lastAgeColor;">$lastAge <em>(Freq: $frequency)</em></td>
+        <td align="center" class="border" style="color:$lastXferErrorsColor;">$lastXferErrors $ifErrors</td>
+        <td align="center" class="border" style="color:$sizeConsistencyColor;">$sizeConsistency</td>
+      </tr>
+EOF
+
+    }
+    # End loop
+
+    # Time set
+    my $now            = timeStamp2(time);
+    my $DUmaxTime      = timeStamp2($Info{DUDailyMaxTime});
+    my $DUInodemaxTime = timeStamp2($Info{DUInodeDailyMaxTime});
+
+    # Show header
+    $header = <<EOF;
+    \${h1(qq{BackupPC: Check})}
+    <p>This check was generated at <strong>\$now</strong>.</p>
+
+    <p>File system pool size usage (\$DUmaxTime) :</p>
+    <div style="background-color:#f1f1f1!important">
+      <div style="color:#fff!important;background-color:#2196F3!important; text-align:center; width:\$Info{DUDailyMax}%">\$Info{DUDailyMax}%</div>
+    </div>
+
+    <p>File system inode size usage (\$DUInodemaxTime) :</p>
+    <div style="background-color:#f1f1f1!important">
+      <div style="color:#fff!important;background-color:#2196F3!important; text-align:center; width:\$Info{DUInodeDailyMax}%">\$Info{DUInodeDailyMax}%</div>
+    </div>
+
+    \${h2("Backups summary")}
+
+    <table class="sortable" id="host_summary_backups" border cellpadding="3" cellspacing="1">
+    <tr class="tableheader">
+        <td>Host (Explore files)</td>
+        <td>Last backup in days</td>
+        <td>Errors</td>
+        <td>Size Consistency</td>
+    </tr>
+    \$str
+    </table>
+EOF
+
+    # Show page
+    my $content = eval ("qq{$header}");
+    Header("BackupPC: Check", $content);
+    Trailer();
+}
+
+1;

--- a/lib/BackupPC/CGI/Check.pm
+++ b/lib/BackupPC/CGI/Check.pm
@@ -47,7 +47,7 @@ sub action
       next if ( $Conf{XferMethod} eq "archive" );
       next if ( !$Privileged && !CheckPermission($host) );
 
-      # Get number of total backups
+      # Get number of total backups (full + incr)
       for ( my $i = 0 ; $i < @Backups ; $i++ ) {
           if ( $Backups[$i]{type} eq "full" ) { $fullCnt++; }
           elsif ( $Backups[$i]{type} eq "incr" ) { $incrCnt++; }
@@ -129,7 +129,7 @@ sub action
         $toosmall = 1;
       }
 
-      # Get result, if we don't have enough backup (< 4) we can't calcul a realist average
+      # If we don't have enough backup (< 4) we can't calcul a realist average
       if ( not $nbBackups > 4) {
         $sizeConsistencyColor = "Gray";
         $sizeConsistency = "Not enough backups";
@@ -156,8 +156,8 @@ EOF
     # End loop
 
     # Time set
-    my $now            = timeStamp2(time);
-    my $DUmaxTime      = timeStamp2($Info{DUDailyMaxTime});
+    my $now = timeStamp2(time);
+    my $DUmaxTime = timeStamp2($Info{DUDailyMaxTime});
     my $DUInodemaxTime = timeStamp2($Info{DUInodeDailyMaxTime});
 
     # Show header
@@ -187,7 +187,6 @@ EOF
     \$str
     </table>
 EOF
-
 
     my $content = eval ("qq{$header}");
     Header("BackupPC: Check", $content);

--- a/lib/BackupPC/CGI/Check.pm
+++ b/lib/BackupPC/CGI/Check.pm
@@ -36,7 +36,7 @@ sub action
 
     # Start loop
     foreach my $host ( GetUserHosts(1) ) {
-      my($incrAge, $reasonHilite, $frequency, $idBackup, $lastAge, $lastAgeColor, $tempState, $tempReason, $lastXferErrors, $lastXferErrorsColor, $ifErrors, $sizeConsistency, $sizeConsistencyColor);
+      my($incrAge, $reasonHilite, $frequency, $lastAge, $lastAgeColor, $tempState, $tempReason, $lastXferErrors, $lastXferErrorsColor, $ifErrors, $sizeConsistency, $sizeConsistencyColor);
       my($shortErr);
       my @Backups = $bpc->BackupInfoRead($host);
 

--- a/lib/BackupPC/Lang/cz.pm
+++ b/lib/BackupPC/Lang/cz.pm
@@ -1128,6 +1128,7 @@ $Lang{Config_file}   = "Konfigurační soubor";
 # $Lang{Hosts_file} = "Hosts soubor";
 $Lang{Current_queues} = "Aktuální fronty";
 $Lang{Documentation}  = "Dokumentace";
+$Lang{Check}          = "Ověření";
 
 #$Lang{Host_or_User_name} = "<small>Jméno uživatele nebo hosta:</small>";
 $Lang{Go}            = "Jdi";

--- a/lib/BackupPC/Lang/de.pm
+++ b/lib/BackupPC/Lang/de.pm
@@ -1140,6 +1140,7 @@ $Lang{Config_file}   = "Konfigurationsdatei";
 # $Lang{Hosts_file} = "Hosts Datei";
 $Lang{Current_queues} = "Warteschlangen";
 $Lang{Documentation}  = "Dokumentation";
+$Lang{Check}          = "Überprüfung";
 
 #$Lang{Host_or_User_name} = "<small>Computer oder Benutzer Name:</small>";
 $Lang{Go}            = "gehe zu";

--- a/lib/BackupPC/Lang/en.pm
+++ b/lib/BackupPC/Lang/en.pm
@@ -1129,6 +1129,7 @@ $Lang{Config_file}   = "Config file";
 # $Lang{Hosts_file} = "Hosts file";
 $Lang{Current_queues} = "Current queues";
 $Lang{Documentation}  = "Documentation";
+$Lang{Check}          = "Check";
 
 #$Lang{Host_or_User_name} = "<small>Host or User name:</small>";
 $Lang{Go}            = "Go";

--- a/lib/BackupPC/Lang/es.pm
+++ b/lib/BackupPC/Lang/es.pm
@@ -1145,6 +1145,7 @@ $Lang{Config_file}   = "Archivo configuraci&oacute;n";
 # $Lang{Hosts_file} = "Archivo Hosts";
 $Lang{Current_queues} = "Colas actuales";
 $Lang{Documentation}  = "Documentaci&oacute;n";
+$Lang{Check}          = "Verificaci&oacute;n";
 
 #$Lang{Host_or_User_name} = "<small>Host o usuario:</small>";
 $Lang{Go}            = "Aceptar";

--- a/lib/BackupPC/Lang/fr.pm
+++ b/lib/BackupPC/Lang/fr.pm
@@ -1141,6 +1141,7 @@ $Lang{Config_file}   = "Fichier de configuration";
 # $Lang{Hosts_file} = "Fichiers des hôtes";
 $Lang{Current_queues} = "Files actuelles";
 $Lang{Documentation}  = "Documentation";
+$Lang{Check}          = "Vérification";
 
 #$Lang{Host_or_User_name} = "<small>Hôte ou Nom d\'utilisateur:</small>";
 $Lang{Go}            = "Chercher";

--- a/lib/BackupPC/Lang/it.pm
+++ b/lib/BackupPC/Lang/it.pm
@@ -1155,6 +1155,7 @@ $Lang{Config_file}   = "File configurazione";
 # $Lang{Hosts_file} = "File host";
 $Lang{Current_queues} = "Code correnti";
 $Lang{Documentation}  = "Documentazione";
+$Lang{Check}          = "Verifica";
 
 #$Lang{Host_or_User_name} = "<small>Host o nome utente:</small>";
 $Lang{Go}            = "Vai";

--- a/lib/BackupPC/Lang/ja.pm
+++ b/lib/BackupPC/Lang/ja.pm
@@ -1112,6 +1112,7 @@ $Lang{Config_file}   = "設定ファイル";
 # $Lang{Hosts_file} = "ホストファイル";
 $Lang{Current_queues} = "現在のキュー";
 $Lang{Documentation}  = "文章";
+$Lang{Check}          = "検証";
 
 #$Lang{Host_or_User_name} = "<small>ホストまたはユーザ名:</small>";
 $Lang{Go}            = "実行";

--- a/lib/BackupPC/Lang/nl.pm
+++ b/lib/BackupPC/Lang/nl.pm
@@ -1142,6 +1142,7 @@ $Lang{Config_file}   = "Configuratiebest.";
 # $Lang{Hosts_file} = "Hosts-bestand";
 $Lang{Current_queues} = "Huidige wachtrij";
 $Lang{Documentation}  = "Documentatie";
+$Lang{Check}          = "Verificatie";
 
 #$Lang{Host_or_User_name} = "<small>Machine of gebruikersnaam:</small>";
 $Lang{Go}            = "Start";

--- a/lib/BackupPC/Lang/pl.pm
+++ b/lib/BackupPC/Lang/pl.pm
@@ -1110,6 +1110,7 @@ $Lang{Config_file}   = "Plik Konfiguracyjny";
 # $Lang{Hosts_file} = "Plik Hostów";
 $Lang{Current_queues} = "Aktualne kolejki";
 $Lang{Documentation}  = "Dokumentacja";
+$Lang{Check}          = "Weryfikacja";
 
 #$Lang{Host_or_User_name} = "<small>Host lub nazwa użytkownika:</small>";
 $Lang{Go}            = "Idź";

--- a/lib/BackupPC/Lang/pt_br.pm
+++ b/lib/BackupPC/Lang/pt_br.pm
@@ -1135,6 +1135,7 @@ $Lang{Config_file}   = "Arquivo configuração";
 # $Lang{Hosts_file} = "Arquivo Hosts";
 $Lang{Current_queues} = "Filas atuais";
 $Lang{Documentation}  = "Documentação";
+$Lang{Check}          = "Weryfikacja";
 
 #$Lang{Host_or_User_name} = "<small>Host ou usuário:</small>";
 $Lang{Go}            = "Aceitar";

--- a/lib/BackupPC/Lang/ru.pm
+++ b/lib/BackupPC/Lang/ru.pm
@@ -1131,6 +1131,7 @@ $Lang{Config_file}   = "Config file";
 # $Lang{Hosts_file} = "Hosts file";
 $Lang{Current_queues} = "Сводка по Очередям";
 $Lang{Documentation}  = "Руководство";
+$Lang{Check}          = "Проверка";
 
 #$Lang{Host_or_User_name} = "<small>Host or User name:</small>";
 $Lang{Go}            = "Найти";

--- a/lib/BackupPC/Lang/uk.pm
+++ b/lib/BackupPC/Lang/uk.pm
@@ -1133,6 +1133,7 @@ $Lang{Config_file}   = "Файл конфігурації";
 # $Lang{Hosts_file} = "Hosts file";
 $Lang{Current_queues} = "Поточні черги";
 $Lang{Documentation}  = "Документація (англ)";
+$Lang{Check}          = "Перевірка";
 
 #$Lang{Host_or_User_name} = "<small>Host or User name:</small>";
 $Lang{Go}            = "Перейти";

--- a/lib/BackupPC/Lang/zh_CN.pm
+++ b/lib/BackupPC/Lang/zh_CN.pm
@@ -1094,6 +1094,7 @@ $Lang{Config_file}   = "配置文件";
 # $Lang{Hosts_file} = "Hosts file";
 $Lang{Current_queues} = "当前队列";
 $Lang{Documentation}  = "文档资料";
+$Lang{Check}          = "核对";
 
 #$Lang{Host_or_User_name} = "<small>Host or User name:</small>";
 $Lang{Go}            = "确定";


### PR DESCRIPTION
# BackupPC-Check

As part of our research project, I work on the development of a BackupPC’s plugin : BackupPC-Check

In my business, integrity of backups are carried out by a human with the BackupPC interface, we check last backup age, xfer errors and average backups sizes. This is a repetitive, lengthy and inefficient task.

So, I've created a plugin to get information quickly and efficiently, required for these manual checks.

Here below, an example of the result :

![check](https://user-images.githubusercontent.com/1780479/108377977-dc83e880-7204-11eb-8111-6d37c158d6de.png)


You can see here that it is possible to have the crucial information, of all the active hosts in a single and quick view. Problems are highlighted in red so they can be spotted very quickly during routine checks.

We assume that an important scale difference in regards to the latest backups should attract our attention. Thus, the consistency of the size is calculated on the average and alert the user if the latest backup are higher or lower than usual.

Here i share this project to the BackupPC community to collect your views, comments and ideas.

For now, i need to declare the new %ActionDispatch in BackupPC_Admin.pl to run the plugin, to get my ?action=check url.
In my idea, i would like to propose a fork in order to integrate these functionalities.


### More screenshot of the result :


**Backup is active**
![active](https://user-images.githubusercontent.com/1780479/108528655-efb1b980-72d3-11eb-9800-f2e56467b5f5.png)

**Backup have Xfrer errors**
![errors](https://user-images.githubusercontent.com/1780479/108529001-4f0fc980-72d4-11eb-840f-7ea1d34da265.png)

**Backup are too old**
![freq](https://user-images.githubusercontent.com/1780479/108530163-964a8a00-72d5-11eb-9e4c-ab22a2dc76cc.png)

**Backup is too big or too small ...**

![toosmall](https://user-images.githubusercontent.com/1780479/108528819-1d96fe00-72d4-11eb-99d7-58254caaa587.png)
![toobig](https://user-images.githubusercontent.com/1780479/108528829-1ff95800-72d4-11eb-9577-31a0c67cb9bf.png)

**... so warn us, we feel there is a discrepancy**

![anomalous](https://user-images.githubusercontent.com/1780479/108529550-dcebb480-72d4-11eb-8efa-f90a8c75544d.png)


**If we don't have enough backup (< 4) we can't calcul a realist average :**

![notenough](https://user-images.githubusercontent.com/1780479/108529868-3c49c480-72d5-11eb-85ef-241c44b59159.png)

