### PR TITLE
Add client display name

### DIFF
--- a/conf/config.pl
+++ b/conf/config.pl
@@ -1903,6 +1903,12 @@ $Conf{ClientNameAlias} = undef;
 #
 $Conf{ClientComment} = undef;
 
+#
+# User-definable comment string that appears in the host list.
+# The value is otherwise ignored by BackupPC.
+#
+$Conf{ClientDisplayName} = undef;
+
 ###########################################################################
 # Email reminders, status and messages
 # (can be overridden in the per-PC config.pl)
@@ -2297,6 +2303,7 @@ $Conf{CgiUserConfigEdit} = {
     ClientCharset             => 1,
     ClientCharsetLegacy       => 1,
     ClientComment             => 1,
+    ClientDisplayName         => 1,
     ClientNameAlias           => 1,
     ClientShareName2Path      => 1,
     ClientTimeout             => 1,

--- a/lib/BackupPC/CGI/EditConfig.pm
+++ b/lib/BackupPC/CGI/EditConfig.pm
@@ -469,6 +469,7 @@ our %ConfigMenu = (
             {name => "PingMaxMsec"},
 
             {text => "CfgEdit_Title_Other"},
+            {name => "ClientDisplayName"},
             {name => "ClientComment"},
             {name => "ClientTimeout"},
             {name => "MaxOldPerPCLogFiles"},

--- a/lib/BackupPC/CGI/Lib.pm
+++ b/lib/BackupPC/CGI/Lib.pm
@@ -535,10 +535,17 @@ EOF
     NavSectionTitle($Lang->{Hosts});
     if ( defined($Hosts) && %$Hosts > 0 && @hosts ) {
         foreach my $host ( @hosts ) {
+            my $hostConf = $bpc->ConfigDataRead($host);
             NavLink("?host=${EscURI($host)}", $host)
               if ( @hosts < $Conf{CgiNavBarAdminAllHosts} );
             my $sel = " selected" if ( $host eq $In{host} );
-            $hostSelectbox .= "<option value=\"?host=${EscURI($host)}\"$sel>$host</option>";
+            $hostSelectbox .= "<option value=\"?host=${EscURI($host)}\"$sel>";
+            if ( defined($hostConf->{ClientDisplayName}) ) {
+                $hostSelectbox .= ${EscHTML($hostConf->{ClientDisplayName})} . ' (' . $host . ')';
+            } else {
+                $hostSelectbox .= $host;
+            }
+            $hostSelectbox .= "</option>"
         }
     }
     if ( @hosts >= $Conf{CgiNavBarAdminAllHosts} ) {

--- a/lib/BackupPC/Config/Meta.pm
+++ b/lib/BackupPC/Config/Meta.pm
@@ -329,6 +329,7 @@ use vars qw(%ConfigMeta);
     NmbLookupCmd         => "string",
     NmbLookupFindHostCmd => "string",
     ClientComment        => "string",
+    ClientDisplayName    => "string",
 
     FixedIPNetBiosNameCheck => "boolean",
     PingCmd                 => "string",
@@ -512,6 +513,7 @@ use vars qw(%ConfigMeta);
             CompressLevel             => "boolean",
             ClientNameAlias           => "boolean",
             ClientComment             => "boolean",
+            ClientDisplayName         => "boolean",
             DumpPreUserCmd            => "boolean",
             DumpPostUserCmd           => "boolean",
             RestorePreUserCmd         => "boolean",


### PR DESCRIPTION
Hello !

I have been using BackupPC for a long time and my backup list is quite long (over 20 hosts).

It's hard to find a host in this list because I only have IP addresses.
My feature is simple : Add an optional _ClientDisplayName_ field to find the host more easily in the list of hosts.

When _ClientDisplayName_ is specified, the host address is displayed in parentheses.
Example: **127.0.0.1** becomes **localhost (127.0.0.1)** in the list of hosts

![hosts-list](https://user-images.githubusercontent.com/20095205/112716741-803d7400-8ee8-11eb-98a0-1faec5f5cfc2.jpg)

![ClientDisplayName](https://user-images.githubusercontent.com/20095205/112716740-7fa4dd80-8ee8-11eb-9ec8-187a94d698d2.jpg)