### PR TITLE
avoid "Old package separator used in string" warnings

### DIFF
--- a/bin/BackupPC_backupDelete
+++ b/bin/BackupPC_backupDelete
@@ -99,7 +99,7 @@ if (   $opts{h} !~ /^([\w\.\s-]+)$/
 }
 my $Host = $opts{h};
 if ( defined(my $error = $bpc->ConfigRead($Host)) ) {
-    print(STDERR "BackupPC_backupDelete: Can't read $Host's config file: $error\n");
+    print(STDERR "BackupPC_backupDelete: Can't read ${Host}'s config file: $error\n");
     exit(1);
 }
 %Conf = $bpc->Conf();

--- a/bin/BackupPC_backupDuplicate
+++ b/bin/BackupPC_backupDuplicate
@@ -86,7 +86,7 @@ if (   $opts{h} !~ /^([\w\.\s-]+)$/
 }
 my $Host = $opts{h};
 if ( defined(my $error = $bpc->ConfigRead($Host)) ) {
-    print(STDERR "BackupPC_backupDuplicate: Can't read $Host's config file: $error\n");
+    print(STDERR "BackupPC_backupDuplicate: Can't read ${Host}'s config file: $error\n");
     exit(1);
 }
 %Conf = $bpc->Conf();

--- a/bin/BackupPC_migrateV3toV4
+++ b/bin/BackupPC_migrateV3toV4
@@ -108,7 +108,7 @@ my($Host, $LogLevel, $Compress, $SrcDir, $DestDir, $BkupNum, $Inode, $DeltaInfo,
 foreach my $h ( defined($opts{h}) ? ($opts{h}) : sort(keys(%$Hosts)) ) {
     $Host = $h;
     if ( defined(my $error = $bpc->ConfigRead($Host)) ) {
-        print("BackupPC_migrateV3toV4: Can't read $Host's config file: $error\n");
+        print("BackupPC_migrateV3toV4: Can't read ${Host}'s config file: $error\n");
         exit(1);
     }
     #


### PR DESCRIPTION
Seems with perl 5.38.0 the old package separator (`'`) became deprecated, causing a warning when found.