### PR TITLE
fix make PoolSizeNightlyUpdatePeriod work together with BackupPCNightlyPeriod

### DIFF
--- a/bin/BackupPC
+++ b/bin/BackupPC
@@ -520,9 +520,9 @@ sub Main_TryToRun_nightly
                     #
                     my $clear;
                     if ( $Conf{PoolSizeNightlyUpdatePeriod} > 0 ) {
-			my $perNight = int( $Conf{PoolSizeNightUpdatePeriod} / $Conf{BackupPCNightlyPeriod} );
+                        my $perNight = int( $Conf{PoolSizeNightlyUpdatePeriod} / $Conf{BackupPCNightlyPeriod} );
                         $clear = ($perNight == 0) ||
-			    ($i % $perNight) == ( ($Info->{PoolSizeNightlyPhase} / $Conf{BackupPCNightlyPeriod})% $perNight);
+                            ($i % $perNight) == ( ($Info->{PoolSizeNightlyPhase} / $Conf{BackupPCNightlyPeriod})% $perNight);
                     }
                     #print(LOG $bpc->timeStamp, "updating $p size of $i (clear = $clear, phase = $Info->{PoolSizeNightlyPhase},"
                     #                         . " \$Conf{PoolSizeNightlyUpdatePeriod} = $Conf{PoolSizeNightlyUpdatePeriod})\n");

--- a/bin/BackupPC_refCountUpdate
+++ b/bin/BackupPC_refCountUpdate
@@ -873,7 +873,7 @@ sub updateTotalRefCnt
             #
             my $fullPoolScan;
             if ( $Conf{PoolSizeNightlyUpdatePeriod} > 0 && defined($opts{P}) ) {
-                my $perNight = int( $Conf{PoolSizeNightUpdatePeriod} / $Conf{BackupPCNightlyPeriod} );
+                my $perNight = int( $Conf{PoolSizeNightlyUpdatePeriod} / $Conf{BackupPCNightlyPeriod} );
                 $fullPoolScan = ($perNight == 0) ||
                   (int($refCntFile / 8) % $perNight) == ( ($opts{P} / $Conf{BackupPCNightlyPeriod}) % $perNight);
             }


### PR DESCRIPTION
This is a fix for Pull Request "make PoolSizeNightlyUpdatePeriod work together with BackupPCNightlyPeriod#560" where I accidentally forgot the latest fixes I head.